### PR TITLE
Vectorize distance calculations

### DIFF
--- a/AegeanTools/angle_tools.py
+++ b/AegeanTools/angle_tools.py
@@ -145,7 +145,7 @@ def gcd(ra1, dec1, ra2, dec2):
     dlat = dec2 - dec1
     a = np.sin(np.radians(dlat) / 2) ** 2
     a += np.cos(np.radians(dec1)) * np.cos(np.radians(dec2)) * np.sin(np.radians(dlon) / 2) ** 2
-    sep = np.degrees(2 * np.arcsin(min(1, np.sqrt(a))))
+    sep = np.degrees(2 * np.arcsin(np.minimum(1, np.sqrt(a))))
     return sep
 
 

--- a/AegeanTools/cluster.py
+++ b/AegeanTools/cluster.py
@@ -45,7 +45,7 @@ def norm_dist(src1, src2):
         The normalised distance.
 
     """
-    if src1 == src2:
+    if np.all(src1 == src2):
         return 0
     dist = gcd(src1.ra, src1.dec, src2.ra, src2.dec) # degrees
 
@@ -81,7 +81,7 @@ def sky_dist(src1, src2):
     :func:`AegeanTools.angle_tools.gcd`
     """
 
-    if src1 == src2:
+    if np.all(src1 == src2):
         return 0
     return gcd(src1.ra, src1.dec, src2.ra, src2.dec) # degrees
 


### PR DESCRIPTION
This allows for numpy recarrays or pandas DataFrames to be used instead of SimpleSource in distance calculations. It will eventually enable speeding up the `regroup` operation.

```python


In [1]:
   ...: X = np.random.rand(1000, 6)
   ...: Xr = np.rec.array(X.view([('ra', 'f8'), ('dec', 'f8'),
   ...:                           ('a', 'f8'), ('b', 'f8'),
   ...:                           ('pa', 'f8'),
   ...:                           ('peak_flux', 'f8')]).ravel())
   ...:

In [2]: def to_ss(x):
   ...:     "Convert numpy.rec to SimpleSource"
   ...:     out = SimpleSource()
   ...:     for f in Xr.dtype.names:
   ...:         setattr(out, f, getattr(x, f))
   ...:     return out
   ...:

In [6]: from AegeanTools.cluster import norm_dist

In [7]: from AegeanTools.models import SimpleSource

In [8]: Xss = [to_ss(x) for x in Xr]

In [9]: %timeit [norm_dist(Xss[0], Xi) for Xi in Xss]
10 loops, best of 3: 70 ms per loop

In [10]: %timeit [norm_dist(Xr[0], Xi) for Xi in Xr]
1 loop, best of 3: 166 ms per loop

In [11]: %timeit norm_dist(Xr[0], Xr)
1000 loops, best of 3: 693 µs per loop
```

This shows that vectorized distance calculations can reduce time from 70ms to 693 µs, i.e. 100x. It's just a question of how many distances need to be computed at a time, and whether the data can efficiently be stored and operated over as arrays.