### PR TITLE
A first attempt at vectorized regroup

### DIFF
--- a/AegeanTools/cluster.py
+++ b/AegeanTools/cluster.py
@@ -135,6 +135,72 @@ def pairwise_ellpitical_binary(sources, eps, far=None):
     return distances
 
 
+def regroup_vectorized(srccat, eps, far=None, dist=norm_dist):
+    """
+    Parameters
+    ----------
+    srccat : np.rec.arry or pd.DataFrame
+        Should have the following fields[units]:
+        ra[deg],dec[deg], a[arcsec],b[arcsec],pa[deg], peak_flux[any]
+    eps : float
+        maximum normalised distance within which sources are considered to be
+        grouped
+    far : float
+        (degrees) sources that are further than this distance apart will not
+        be grouped, and will not be tested.
+        Default = 0.5.
+    dist : func
+        a function that calculates the distance between a source and each
+        element of an array of sources.
+        Default = :func:`AegeanTools.cluster.norm_dist`
+
+    Returns
+    -------
+    islands : list of lists
+        Each island contians integer indices for members from srccat
+        (in descending dec order).
+    """
+    if far is None:
+        far = 0.5  # 10*max(a.a/3600 for a in srccat)
+
+    # most negative declination first
+    # XXX: kind='mergesort' ensures stable sorting for determinism.
+    #      Do we need this?
+    order = np.argsort(srccat.dec, kind='mergesort')[::-1]
+    # TODO: is it better to store groups as arrays even if appends are more
+    #       costly?
+    groups = [[order[0]]]
+    for idx in order[1:]:
+        rec = srccat[idx]
+        # TODO: Find out if groups are big enough for this to give us a speed
+        #       gain. If not, get distance to all entries in groups above
+        #       decmin simultaneously.
+        decmin = rec.dec - far
+        for group in reversed(groups):
+            # when an island's largest (last) declination is smaller than
+            # decmin, we don't need to look at any more islands
+            if srccat.dec[group[-1]] < decmin:
+                # new group
+                groups.append([idx])
+            rafar = far / np.cos(np.radians(rec.dec))
+            group_recs = np.take(srccat, group, mode='clip')
+            group_recs = group_recs[abs(rec.ra - group_recs.ra) <= rafar]
+            if len(group_recs) and dist(rec, group_recs).min() < eps:
+                group.append(idx)
+                break
+        else:
+            # new group
+            groups.append([idx])
+
+    # TODO?: a more numpy-like interface would return only an array providing
+    #        the mapping:
+    #    group_idx = np.empty(len(srccat), dtype=int)
+    #    for i, group in enumerate(groups):
+    #        group_idx[group] = i
+    #    return group_idx
+    return groups
+
+
 def regroup(catalog, eps, far=None, dist=norm_dist):
     """
     Regroup the islands of a catalog according to their normalised distance.
@@ -180,50 +246,28 @@ def regroup(catalog, eps, far=None, dist=norm_dist):
             log.error("catalog is not understood.")
             log.error("catalog: Should be a list of objects with the following properties[units]:\n" +
                       "ra[deg],dec[deg], a[arcsec],b[arcsec],pa[deg], peak_flux[any]")
-            raise e
+            raise
 
     log.info("Regrouping islands within catalog")
     log.debug("Calculating distances")
 
-    # most negative declination first
-    srccat = sorted(srccat, key=lambda x: x.dec)
-
     if far is None:
         far = 0.5  # 10*max(a.a/3600 for a in srccat)
 
-    groups = {0: [srccat[0]]}
-    last_group = 0
-
-    # to parallelize this code, break the list into one part per core
-    # compute the groups within each part
-    # when the groups are found, check the last/first entry of pairs of groups to see if they need to be joined together
-    for s1 in srccat[1:]:
-        done = False
-        # when an islands largest (last) declination is smaller than decmin, we don't need to look at any more islands
-        decmin = s1.dec - far
-        for g in range(last_group, -1, -1):
-            if groups[g][-1].dec < decmin:
-                break
-            rafar = far / np.cos(np.radians(s1.dec))
-            for s2 in groups[g]:
-                if abs(s2.ra - s1.ra) > rafar:
-                    continue
-                if dist(s1, s2) < eps:
-                    groups[g].append(s1)
-                    done = True
-                    break
-            if done:
-                break
-        if not done:
-            last_group += 1
-            groups[last_group] = [s1]
+    srccat_array = np.rec.fromrecords(
+        [(s.ra, s.dec, s.a, s.b, s.pa, s.peak_flux)
+         for s in srccat],
+        names=['ra', 'dec', 'a', 'b', 'pa', 'peak_flux'])
+    groups = regroup_vectorized(srccat_array, eps=eps, far=far, dist=dist)
+    groups = [[srccat[idx] for idx in group]
+              for group in groups]
 
     islands = []
     # now that we have the groups, we relabel the sources to have (island,component) in flux order
     # note that the order of sources within an island list is not changed - just their labels
-    for isle in groups.keys():
-        for comp, src in enumerate(sorted(groups[isle], key=lambda x: -1*x.peak_flux)):
+    for isle, group in enumerate(groups):
+        for comp, src in enumerate(sorted(group, key=lambda x: -1*x.peak_flux)):
             src.island = isle
             src.source = comp
-        islands.append(groups[isle])
+        islands.append(group)
     return islands

--- a/AegeanTools/cluster.py
+++ b/AegeanTools/cluster.py
@@ -137,6 +137,11 @@ def pairwise_ellpitical_binary(sources, eps, far=None):
 
 def regroup_vectorized(srccat, eps, far=None, dist=norm_dist):
     """
+    Regroup the islands of a catalog according to their normalised distance.
+
+    Assumes srccat is recarray-like for efficiency.
+    Return a list of island groups.
+
     Parameters
     ----------
     srccat : np.rec.arry or pd.DataFrame


### PR DESCRIPTION
I think that the data structure (plain old Python objects) that is used by regroup is one of the reasons it can be slow.

For now I have created a new version of `regroup`, under the name `regroup_vectorized`, that assumes the input is a numpy recarray or a pandas DataFrame (the latter untested so far). It exploits this for things like vectorized distance calculations.

I've not yet benchmarked this. The conversion to and from recarray is unnecessarily slow (although perhaps not the bottleneck), and in the VAST context, we would want to use `regroup_vectorized` directly, as we have exploit the database structure when constructing a recarray.

One of the main questions in terms of optimisation is: when working with something like the full VAST dataset, how big to the groups tend to get? how many groups tend to be below the decmin threshold?

Hopefully I'll soon have the data with which to benchmark this.

I have left in here some comments related to potential optimisations or interface enhancements.

Ping @mebell.