### PR TITLE
reformat the help text and add new option --colprefix

### DIFF
--- a/AegeanTools/catalogs.py
+++ b/AegeanTools/catalogs.py
@@ -143,7 +143,7 @@ def update_meta_data(meta=None):
     return meta
 
 
-def save_catalog(filename, catalog, meta=None):
+def save_catalog(filename, catalog, meta=None, prefix=None):
     """
     Save a catalogue of sources using filename as a model. Meta data can be written to some file types
     (fits, votable).
@@ -166,6 +166,9 @@ def save_catalog(filename, catalog, meta=None):
         A list of sources to write. Sources must be of type :class:`AegeanTools.models.OutputSource`,
         :class:`AegeanTools.models.SimpleSource`, or :class:`AegeanTools.models.IslandSource`.
 
+    prefix : str
+        Prepend each column name with "prefix_". Default is to prepend nothing.
+
     meta : dict
         Meta data to be written to the output file. Support for metadata depends on file type.
 
@@ -182,13 +185,13 @@ def save_catalog(filename, catalog, meta=None):
     elif extension in ['db', 'sqlite']:
         writeDB(filename, catalog, meta)
     elif extension in ['hdf5', 'fits', 'vo', 'vot', 'xml']:
-        write_catalog(filename, catalog, extension, meta)
+        write_catalog(filename, catalog, extension, meta, prefix=prefix)
     elif extension in ascii_table_formats.keys():
-        write_catalog(filename, catalog, fmt=ascii_table_formats[extension], meta=meta)
+        write_catalog(filename, catalog, fmt=ascii_table_formats[extension], meta=meta, prefix=prefix)
     else:
         log.warning("extension not recognised {0}".format(extension))
         log.warning("You get tab format")
-        write_catalog(filename, catalog, fmt='tab')
+        write_catalog(filename, catalog, fmt='tab', prefix=prefix)
     return
 
 
@@ -341,7 +344,7 @@ def table_to_source_list(table, src_type=OutputSource):
     return source_list
 
 
-def write_catalog(filename, catalog, fmt=None, meta=None):
+def write_catalog(filename, catalog, fmt=None, meta=None, prefix=None):
     """
     Write a catalog (list of sources) to a file with format determined by extension.
 
@@ -361,6 +364,9 @@ def write_catalog(filename, catalog, fmt=None, meta=None):
     fmt : str
         The file format extension.
 
+    prefix : str
+        Prepend each column name with "prefix_". Default is to prepend nothing.
+
     meta : dict
         A dictionary to be used as metadata for some file types (fits, VOTable).
 
@@ -370,6 +376,11 @@ def write_catalog(filename, catalog, fmt=None, meta=None):
     """
     if meta is None:
         meta = {}
+
+    if prefix is None:
+        pre=''
+    else:
+        pre = prefix + '_'
 
     def writer(filename, catalog, fmt=None):
         # construct a dict of the data
@@ -387,7 +398,7 @@ def write_catalog(filename, catalog, fmt=None, meta=None):
                     col_name = 'lat'+name[3:]
                 elif name.endswith('dec'):
                     col_name = name[:-3] + 'lat'
-
+            col_name = pre + col_name
             tab_dict[col_name] = [getattr(c, name, None) for c in catalog]
             name_list.append(col_name)
         t = Table(tab_dict, meta=meta)

--- a/scripts/aegean
+++ b/scripts/aegean
@@ -135,9 +135,6 @@ if __name__ == "__main__":
                       help='If --save is True, then this specifies the base name of the background and noise images. ' +
                            '[default: inferred from input image]')
 
-#    parser.add_option('--measure', dest='measure', action='store_true', default=False,
-#                      help='Enable forced measurement mode. Requires an input source list via --input. ' +
-#                           'Sets --find to false. [default: false]')
     parser.add_option('--priorized', dest='priorized', default=0, type=int,
                       help="Enable priorized fitting level n=[1,2,3]. 1=fit flux, 2=fit flux/position, 3=fit flux/position/shape. " + 
                            "See the GitHub wiki for more details." )
@@ -321,10 +318,6 @@ if __name__ == "__main__":
         options.outfile = open(options.outfile, 'w')
 
     sources = []
-
-#    # do forced measurements using catfile
-#    if options.measure and options.priorized == 0:
-#        raise NotImplementedError("forced measurements are not supported")
 
     if options.priorized > 0:
         if options.ratio is not None:

--- a/scripts/aegean
+++ b/scripts/aegean
@@ -14,8 +14,8 @@ import lmfit
 import astropy
 import logging
 import logging.config
-
-from optparse import OptionParser
+import argparse
+#from optparse import OptionParser
 
 # need Region in the name space in order to be able to unpickle it
 try:
@@ -63,99 +63,120 @@ def check_projection(filename, options):
     return
 
 if __name__ == "__main__":
-    usage = "usage: %prog [options] FileName.fits"
-    parser = OptionParser(usage=usage)
-    parser.add_option("--find", dest='find', action='store_true', default=False,
-                      help='Source finding mode. [default: true, unless --save or --measure are selected]')
-    parser.add_option("--cores", dest="cores", type="int", default=None,
-                      help="Number of CPU cores to use for processing [default: all cores]")
-    parser.add_option("--debug", dest="debug", action="store_true", default=False,
-                      help="Enable debug mode. [default: false]")
-    parser.add_option("--hdu", dest="hdu_index", type="int", default=0,
-                      help="HDU index (0-based) for cubes with multiple images in extensions. [default: 0]")
-    parser.add_option("--out", dest='outfile', default=None,
-                      help="Destination of Aegean catalog output. [default: No output]")
-    parser.add_option("--table", dest='tables', default=None,
-                      help="Additional table outputs, format inferred from extension. [default: none]")
-    parser.add_option("--tformats", dest='table_formats', action="store_true", default=False,
-                      help='Show a list of table formats supported in this install, and their extensions')
-    parser.add_option("--forcerms", dest='rms', type='float', default=None,
-                      help="Assume a single image noise of rms. [default: None]")
-    parser.add_option("--forcebkg", dest='bkg', type='float', default=None,
-                      help="Assume a single image background of bkg. [default: None]")
-    parser.add_option("--noise", dest='noiseimg', default=None,
-                      help="A .fits file that represents the image noise (rms), created from Aegean with --save " +
-                           "or BANE. [default: none]")
-    parser.add_option('--background', dest='backgroundimg', default=None,
-                      help="A .fits file that represents the background level, created from Aegean with --save " +
-                           "or BANE. [default: none]")
-    parser.add_option('--psf', dest='imgpsf', default=None,
-                      help="A .fits file that represents the local PSF. ")
-    parser.add_option('--autoload', dest='autoload', action="store_true", default=False,
-                      help="Automatically look for background, noise, region, and psf files "+
-                           "using the input filename as a hint. [default: don't do this]")
+    parser = argparse.ArgumentParser(prog='aegean', prefix_chars='-')
+    parser.add_argument('image', nargs='?', default=None)
+    group1 = parser.add_argument_group('Configuration Options:')
 
-    parser.add_option("--maxsummits", dest='max_summits', type='float', default=None,
-                      help="If more than *maxsummits* summits are detected in an island, no fitting is done, " +
-                           "only estimation. [default: no limit]")
-    parser.add_option('--seedclip', dest='innerclip', type='float', default=5,
-                      help='The clipping value (in sigmas) for seeding islands. [default: 5]')
-    parser.add_option('--floodclip', dest='outerclip', type='float', default=4,
-                      help='The clipping value (in sigmas) for growing islands. [default: 4]')
-    parser.add_option('--beam', dest='beam', type='float', nargs=3, default=None,
-                      help='The beam parameters to be used is "--beam major minor pa" all in degrees. ' +
-                           '[default: read from fits header].')
-    parser.add_option('--telescope', dest='telescope', type=str, default=None,
-                      help='The name of the telescope used to collect data. [MWA|VLA|ATCA|LOFAR]')
-    parser.add_option('--lat', dest='lat', type=float, default=None,
-                      help='The latitude of the telescope used to collect data.')
+    group1.add_argument("--find", dest='find', action='store_true', default=False,
+                        help='Source finding mode. [default: true, unless --save or --measure are selected]')
+    group1.add_argument("--cores", dest="cores", type=int, default=None,
+                        help="Number of CPU cores to use for processing [default: all cores]")
+    group1.add_argument("--hdu", dest="hdu_index", type=int, default=0,
+                        help="HDU index (0-based) for cubes with multiple images in extensions. [default: 0]")
 
-    parser.add_option('--slice', dest='slice', type=int, default=None,
-                      help='If the input data is a cube, then this slice will determine which slice will be processed by aegean')
+    group1.add_argument('--beam', dest='beam', type=float, nargs=3, default=None,
+                        help='The beam parameters to be used is "--beam major minor pa" all in degrees. ' +
+                             '[default: read from fits header].')
+    group1.add_argument('--telescope', dest='telescope', type=str, default=None,
+                        help='The name of the telescope used to collect data. [MWA|VLA|ATCA|LOFAR]')
+    group1.add_argument('--lat', dest='lat', type=float, default=None,
+                        help='The latitude of the telescope used to collect data.')
+    group1.add_argument('--slice', dest='slice', type=int, default=None,
+                        help='If the input data is a cube, then this slice will determine which slice will be processed by aegean')
 
-    parser.add_option('--island', dest='doislandflux', action="store_true", default=False,
-                      help='Also calculate the island flux in addition to the individual components. [default: false]')
-    parser.add_option('--nopositive', dest='nopositive', action="store_true", default=False,
-                      help="Don't report sources with positive fluxes. [default: false]")
-    parser.add_option('--negative', dest='negative', action="store_true", default=False,
-                      help="Report sources with negative fluxes. [default: false]")
-    parser.add_option('--blankout', dest='blank', action="store_true", default=False,
-                      help="Create a blanked output image. [Only works if cores=1].")
-    parser.add_option('--region', dest='region', default=None,
-                      help="Use this regions file to restrict source finding in this image.")
-    parser.add_option('--nocov', dest='docov', action="store_false", default=True,
-                      help="Don't use the covariance of the data in the fitting proccess. [Default = False]")
-    parser.add_option('--condon', dest='condon', action="store_true", default=False,
-                      help="replace errors with those suggested by Condon'97. [Default = False]")
 
-    parser.add_option('--save', dest='save', action="store_true", default=False,
-                      help='Enable the saving of the background and noise images. Sets --find to false. ' +
-                           '[default: false]')
-    parser.add_option('--outbase', dest='outbase', default=None,
-                      help='If --save is True, then this specifies the base name of the background and noise images. ' +
-                           '[default: inferred from input image]')
+    # Input
+    group2 = parser.add_argument_group("Input Options:")
+    group2.add_argument("--forcerms", dest='rms', type=float, default=None,
+                        help="Assume a single image noise of rms. [default: None]")
+    group2.add_argument("--forcebkg", dest='bkg', type=float, default=None,
+                        help="Assume a single image background of bkg. [default: None]")
+    group2.add_argument("--noise", dest='noiseimg', default=None, type=str,
+                        help="A .fits file that represents the image noise (rms), created from Aegean with --save " +
+                             "or BANE. [default: none]")
+    group2.add_argument('--background', dest='backgroundimg', default=None, type=str,
+                        help="A .fits file that represents the background level, created from Aegean with --save " +
+                             "or BANE. [default: none]")
+    group2.add_argument('--psf', dest='imgpsf', default=None, type=str,
+                        help="A .fits file that represents the local PSF. ")
+    group2.add_argument('--autoload', dest='autoload', action="store_true", default=False,
+                        help="Automatically look for background, noise, region, and psf files "+
+                             "using the input filename as a hint. [default: don't do this]")
 
-    parser.add_option('--priorized', dest='priorized', default=0, type=int,
-                      help="Enable priorized fitting level n=[1,2,3]. 1=fit flux, 2=fit flux/position, 3=fit flux/position/shape. " + 
-                           "See the GitHub wiki for more details." )
-    parser.add_option('--ratio', dest='ratio', default=None, type=float,
-                      help="The ratio of synthesized beam sizes (image psf / input catalog psf). " +
-                           "For use with priorized.")
-    parser.add_option('--noregroup', dest='regroup', default=True, action='store_false',
-                      help='Do not regroup islands before priorized fitting.')
-    parser.add_option('--input', dest='input', default=None,
-                      help='If --priorized is used, this gives the filename for a catalog of locations at which ' +
-                           'fluxes will be measured.')
-    parser.add_option('--catpsf', dest='catpsf', default=None,
-                      help='A psf map corresponding to the input catalog. This will allow for the correct resizing of' +
-                           ' sources when the catalog and image psfs differ.')
-    parser.add_option('--versions', dest='file_versions', action="store_true", default=False,
-                      help='Show the file versions of relevant modules. [default: false]')
-    parser.add_option('--cite', dest='cite', action="store_true", default=False,
-                      help='Show citation information.')
+    # Output
+    group3 = parser.add_argument_group("Output Options:")
+    group3.add_argument("--out", dest='outfile', default=None, type=str,
+                        help="Destination of Aegean catalog output. [default: No output]")
+    group3.add_argument("--table", dest='tables', default=None, type=str,
+                        help="Additional table outputs, format inferred from extension. [default: none]")
+    group3.add_argument("--tformats", dest='table_formats', action="store_true", default=False,
+                        help='Show a list of table formats supported in this install, and their extensions')
+    group3.add_argument('--blankout', dest='blank', action="store_true", default=False,
+                        help="Create a blanked output image. [Only works if cores=1].")
 
-    (options, args) = parser.parse_args()
+    # SF config options
+    group4 = parser.add_argument_group("Source finding/fitting configuration options:")
+    group4.add_argument("--maxsummits", dest='max_summits', type=float, default=None,
+                        help="If more than *maxsummits* summits are detected in an island, no fitting is done, " +
+                             "only estimation. [default: no limit]")
+    group4.add_argument('--seedclip', dest='innerclip', type=float, default=5,
+                        help='The clipping value (in sigmas) for seeding islands. [default: 5]')
+    group4.add_argument('--floodclip', dest='outerclip', type=float, default=4,
+                        help='The clipping value (in sigmas) for growing islands. [default: 4]')
+    group4.add_argument('--island', dest='doislandflux', action="store_true", default=False,
+                        help='Also calculate the island flux in addition to the individual components. [default: false]')
+    group4.add_argument('--nopositive', dest='nopositive', action="store_true", default=False,
+                        help="Don't report sources with positive fluxes. [default: false]")
+    group4.add_argument('--negative', dest='negative', action="store_true", default=False,
+                        help="Report sources with negative fluxes. [default: false]")
+    group4.add_argument('--region', dest='region', type=str, default=None,
+                        help="Use this regions file to restrict source finding in this image.")
+    group4.add_argument('--nocov', dest='docov', action="store_false", default=True,
+                        help="Don't use the covariance of the data in the fitting proccess. [Default = False]")
+    group4.add_argument('--condon', dest='condon', action="store_true", default=False,
+                        help="replace errors with those suggested by Condon'97. [Default = False]")
 
+    # priorized fitting
+    group5 = parser.add_argument_group("Priorized Fitting config options:","in addition to the above source fitting options")
+    group5.add_argument('--priorized', dest='priorized', default=0, type=int,
+                        help="Enable priorized fitting level n=[1,2,3]. 1=fit flux, 2=fit flux/position, 3=fit flux/position/shape. " + 
+                             "See the GitHub wiki for more details." )
+    group5.add_argument('--ratio', dest='ratio', default=None, type=float,
+                        help="The ratio of synthesized beam sizes (image psf / input catalog psf). " +
+                             "For use with priorized.")
+    group5.add_argument('--noregroup', dest='regroup', default=True, action='store_false',
+                        help='Do not regroup islands before priorized fitting.')
+    group5.add_argument('--input', dest='input', type=str, default=None,
+                        help='If --priorized is used, this gives the filename for a catalog of locations at which ' +
+                             'fluxes will be measured.')
+    group5.add_argument('--catpsf', dest='catpsf', type=str, default=None,
+                        help='A psf map corresponding to the input catalog. This will allow for the correct resizing of' +
+                             ' sources when the catalog and image psfs differ.')
+
+
+    # Debug and extras
+    group6 = parser.add_argument_group("Extra options")
+    group6.add_argument('--save', dest='save', action="store_true", default=False,
+                        help='Enable the saving of the background and noise images. Sets --find to false. ' +
+                             '[default: false]')
+    group6.add_argument('--outbase', dest='outbase', type=str, default=None,
+                        help='If --save is True, then this specifies the base name of the background and noise images. ' +
+                             '[default: inferred from input image]')
+    group6.add_argument("--debug", dest="debug", action="store_true", default=False,
+                        help="Enable debug mode. [default: false]")
+    group6.add_argument('--versions', dest='file_versions', action="store_true", default=False,
+                        help='Show the file versions of relevant modules. [default: false]')
+    group6.add_argument('--cite', dest='cite', action="store_true", default=False,
+                        help='Show citation information.')
+
+
+#    (options, args) = parser.parse_args()
+    options = parser.parse_args()
+
+    # print help if the user enters no options or filename
+    if len(sys.argv) <= 1:
+        parser.print_help()
+        sys.exit(0)
 
     if options.cite:
         print(__citation__)
@@ -191,13 +212,8 @@ if __name__ == "__main__":
             log.info("h5py not found")
         sys.exit(0)
 
-    # print help if the user enters no options or filename
-    if len(args) == 0:
-        parser.print_help()
-        sys.exit(0)
-
     # check that a valid filename was entered
-    filename = args[0]
+    filename = options.image
     if not os.path.exists(filename):
         log.error("{0} not found".format(filename))
         sys.exit(1)

--- a/scripts/aegean
+++ b/scripts/aegean
@@ -113,6 +113,8 @@ if __name__ == "__main__":
                         help='Show a list of table formats supported in this install, and their extensions')
     group3.add_argument('--blankout', dest='blank', action="store_true", default=False,
                         help="Create a blanked output image. [Only works if cores=1].")
+    group3.add_argument('--colprefix', dest='column_prefix', default=None, type=str,
+                        help='Prepend each column name with "prefix_". Default = prepend nothing')
 
     # SF config options
     group4 = parser.add_argument_group("Source finding/fitting configuration options:")
@@ -400,5 +402,5 @@ if __name__ == "__main__":
                 "PROGVER": "{0}-({1})".format(__version__, __date__),
                 "FITSFILE": filename}
         for t in options.tables.split(','):
-            save_catalog(t, sources)
+            save_catalog(t, sources, prefix=options.column_prefix)
     sys.exit()

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -66,6 +66,16 @@ def test_load_save_catalog():
 
         os.remove(fout)
 
+    # test the prefix is being written.
+    fout = 'a.csv'
+    cat.save_catalog(fout, catalog, meta=None, prefix='test')
+    fout = 'a_comp.csv'
+    if not os.path.exists(fout):
+        raise AssertionError()
+    if 'test_ra' not in open(fout).readlines()[0]:
+        raise AssertionError()
+    os.remove(fout)
+
     for ext in ['reg', 'ann', 'bla']:
         fout = 'a.'+ext
         cat.save_catalog(fout, catalog, meta=None)


### PR DESCRIPTION
Redo the `--help` text to:
1. remove the deprecated option `--measure`
2. reorder and regroup the help text using argparse
3. add a new option `--colprefix`  to add a prefix to all output columns