### PR TITLE
refactor AeRes and add test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ install:
   - pip install .
   - pip install coveralls
   - pip install codacy-coverage
-  - pip install h5py
 # command to run tests
 script:
   - coverage run setup.py test

--- a/AegeanTools/AeRes.py
+++ b/AegeanTools/AeRes.py
@@ -135,10 +135,10 @@ def make_residual(fitsfile, catalog, rfile, mfile=None, add=False, mask=False, f
         residual = data - model
 
     hdulist[0].data = residual
-    hdulist.writeto(rfile, clobber=True)
+    hdulist.writeto(rfile, overwrite=True)
     logging.info("wrote residual to {0}".format(rfile))
     if mfile is not None:
         hdulist[0].data = model
-        hdulist.writeto(mfile, clobber=True)
+        hdulist.writeto(mfile, overwrite=True)
         logging.info("wrote model to {0}".format(mfile))
     return

--- a/AegeanTools/AeRes.py
+++ b/AegeanTools/AeRes.py
@@ -86,8 +86,8 @@ def make_model(sources, shape, wcshelper, mask=False, frac=None, sigma=4):
 
         # positions for which we want to make the model
         x, y = np.mgrid[xmin:xmax, ymin:ymax]
-        x = map(int, x.ravel())
-        y = map(int, y.ravel())
+        x = list(map(int, x.ravel()))
+        y = list(map(int, y.ravel()))
 
         # TODO: understand why xo/yo -1 is needed
         model = fitting.elliptical_gaussian(x, y, src.peak_flux, xo-1, yo-1, sx*FWHM2CC, sy*FWHM2CC, theta)

--- a/AegeanTools/AeRes.py
+++ b/AegeanTools/AeRes.py
@@ -75,7 +75,7 @@ def make_model(sources, shape, wcshelper, mask=False, frac=None, sigma=4):
         if not np.all(np.isfinite([ymin, ymax, xmin, xmax])):
             continue
 
-        if logging.getLogger().isEnabledFor(logging.DEBUG):
+        if logging.getLogger().isEnabledFor(logging.DEBUG):  # pragma: no cover
             logging.debug("Source ({0},{1})".format(src.island, src.source))
             logging.debug(" xo, yo: {0} {1}".format(xo, yo))
             logging.debug(" sx, sy: {0} {1}".format(sx, sy))

--- a/AegeanTools/AeRes.py
+++ b/AegeanTools/AeRes.py
@@ -1,8 +1,16 @@
-import logging
+#! /usr/bin/env python
+"""
+Aegean Residual (AeRes) has the following capability:
+- convert a catalogue into an image model
+- subtract image model from image
+- write model and residual files
+"""
 
+__author__ = "Paul Hancock"
+
+import logging
 import numpy as np
 from astropy.io import fits
-
 from AegeanTools import catalogs, fitting, wcs_helpers
 
 FWHM2CC = 1 / (2 * np.sqrt(2 * np.log(2)))

--- a/AegeanTools/AeRes.py
+++ b/AegeanTools/AeRes.py
@@ -1,0 +1,136 @@
+import logging
+
+import numpy as np
+from astropy.io import fits
+
+from AegeanTools import catalogs, fitting, wcs_helpers
+
+FWHM2CC = 1 / (2 * np.sqrt(2 * np.log(2)))
+
+
+def load_sources(filename):
+    """
+    Open a file, read contents, return a list of all the sources in that file.
+    @param filename:
+    @return: list of OutputSource objects
+    """
+    catalog = catalogs.table_to_source_list(catalogs.load_table(filename))
+    logging.info("read {0} sources from {1}".format(len(catalog), filename))
+    return catalog
+
+
+def make_model(sources, shape, wcshelper, mask=False, frac=None, sigma=4):
+    """
+
+    @param sources: a list of AegeanTools.models.SimpleSource objects
+    @param shape: the shape of the input (and output) image
+    @param wcshelper: an AegeanTools.wcs_helpers.WCSHelper object corresponding to the input image
+    @param mask: If true then mask pixels instead of subtracting the sources
+    @param frac: pixels that are brighter than frac*peak_flux for each source will be masked if mask=True
+    @param sigma: pixels that are brighter than rms*sigma be masked if mask=True
+    @return:
+    """
+
+    # Model array
+    m = np.zeros(shape, dtype=np.float32)
+    factor = 5
+
+    i_count = 0
+    for src in sources:
+        xo, yo, sx, sy, theta = wcshelper.sky2pix_ellipse([src.ra, src.dec], src.a/3600, src.b/3600, src.pa)
+        phi = np.radians(theta)
+
+        # skip sources that have a center that is outside of the image
+        if not 0 < xo < shape[0]:
+            logging.debug("source {0} is not within image".format(src.island))
+            continue
+        if not 0 < yo < shape[1]:
+            logging.debug("source {0} is not within image".format(src.island))
+            continue
+
+        # pixels over which this model is calculated
+        xoff = factor*(abs(sx*np.cos(phi)) + abs(sy*np.sin(phi)))
+        xmin = xo - xoff
+        xmax = xo + xoff
+
+        yoff = factor*(abs(sx*np.sin(phi)) + abs(sy*np.cos(phi)))
+        ymin = yo - yoff
+        ymax = yo + yoff
+
+        # clip to the image size
+        ymin = max(np.floor(ymin), 0)
+        ymax = min(np.ceil(ymax), shape[1])
+
+        xmin = max(np.floor(xmin), 0)
+        xmax = min(np.ceil(xmax), shape[0])
+
+        if not np.all(np.isfinite([ymin, ymax, xmin, xmax])):
+            continue
+
+        if logging.getLogger().isEnabledFor(logging.DEBUG):
+            logging.debug("Source ({0},{1})".format(src.island, src.source))
+            logging.debug(" xo, yo: {0} {1}".format(xo, yo))
+            logging.debug(" sx, sy: {0} {1}".format(sx, sy))
+            logging.debug(" theta, phi: {0} {1}".format(theta, phi))
+            logging.debug(" xoff, yoff: {0} {1}".format(xoff, yoff))
+            logging.debug(" xmin, xmax, ymin, ymax: {0}:{1} {2}:{3}".format(xmin, xmax, ymin, ymax))
+            logging.debug(" flux, sx, sy: {0} {1} {2}".format(src.peak_flux, sx, sy))
+
+        # positions for which we want to make the model
+        x, y = np.mgrid[xmin:xmax, ymin:ymax]
+        x = map(int, x.ravel())
+        y = map(int, y.ravel())
+
+        # TODO: understand why xo/yo -1 is needed
+        model = fitting.elliptical_gaussian(x, y, src.peak_flux, xo-1, yo-1, sx*FWHM2CC, sy*FWHM2CC, theta)
+
+        # Mask the output image if requested
+        if mask:
+            if frac is not None:
+                indices = np.where(model >= (frac*src.peak_flux))
+            else:
+                indices = np.where(model >= (sigma*src.local_rms))
+            model[indices] = np.nan
+
+        m[x, y] += model
+        i_count += 1
+    logging.info("modeled {0} sources".format(i_count))
+    return m
+
+
+def make_residual(fitsfile, catalog, rfile, mfile=None, add=False, mask=False, frac=None, sigma=4):
+    """
+
+    @param fitsfile: Input fits image filename
+    @param catalog: Input catalog filename of a type supported by Aegean
+    @param rfile: Residual image filename
+    @param mfile: model image filename
+    @param add: add the model instead of subtracting it
+    @param mask: If true then mask pixels instead of subtracting the sources
+    @param frac: pixels that are brighter than frac*peak_flux for each source will be masked if mask=True
+    @return:
+    """
+    source_list = load_sources(catalog)
+    # force two axes so that we dump redundant stokes/freq axes if they are present.
+    hdulist = fits.open(fitsfile, naxis=2)
+    # ignore dimensions of length 1
+    data = np.squeeze(hdulist[0].data)
+    header = hdulist[0].header
+
+    wcshelper = wcs_helpers.WCSHelper.from_header(header)
+
+    model = make_model(source_list, data.shape, wcshelper, mask, frac, sigma)
+
+    if add or mask:
+        residual = data + model
+    else:
+        residual = data - model
+
+    hdulist[0].data = residual
+    hdulist.writeto(rfile, clobber=True)
+    logging.info("wrote residual to {0}".format(rfile))
+    if mfile is not None:
+        hdulist[0].data = model
+        hdulist.writeto(mfile, clobber=True)
+        logging.info("wrote model to {0}".format(mfile))
+    return

--- a/AegeanTools/__init__.py
+++ b/AegeanTools/__init__.py
@@ -11,7 +11,7 @@ generally.
 """
 __author__ = 'Paul Hancock'
 __version__ = '2.0.2'
-__date__ = '2018-06-21'
+__date__ = '2018-07-02'
 __citation__ = """
 % If your work makes use of AegeanTools please cite the following papers as appropriate:
 

--- a/AegeanTools/fitting.py
+++ b/AegeanTools/fitting.py
@@ -804,7 +804,7 @@ def condon_errors(source, theta_n, psf=None):
     source : :class:`AegeanTools.models.SimpleSource`
         The source which was fit.
 
-    theta_n : float
+    theta_n : float or None
         A measure of the beam sampling. (See Condon'97).
 
     psf : :class:`AegeanTools.fits_image.Beam`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 General
 - Drop requirement for h5py
 - Drop support for h5py since it doesn't work
--
+
+AeRes
+- refactored functionality into `AegeanTools/AeRes.py`
+- help text is now printed `AeRes` is run without arguments
+- fix a bug that caused by comparing `map` to a `float` in python3 (h/t Tom F.)
+
 
 2018-06-28
 ==========

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
+2018-07-02
+==========
+General
+- Drop requirement for h5py
+- Drop support for h5py since it doesn't work
+-
+
 2018-06-28
-============
+==========
 BANE
  - multiple changes that allow BANE to be run in memory constrained enviornments
  - force image segmentation to always be in horizontal stripes

--- a/scripts/AeRes
+++ b/scripts/AeRes
@@ -1,150 +1,21 @@
 #! /usr/bin/env python
-from __future__ import print_function
-
 """
  Tool for making residual images with Aegean tables as input
 """
+from __future__ import print_function
+
+from AegeanTools.AeRes import make_residual
+
+import logging
+from optparse import OptionParser
+import sys
+
 __author__ = 'Paul Hancock'
 __version__ = 'v0.2.5'
 __date__ = '2017-05-12'
 
-from AegeanTools import catalogs, wcs_helpers, fitting
-from astropy.io import fits
-import logging
-import numpy as np
-from optparse import OptionParser
-import sys
 
 # global constants
-FWHM2CC = 1 / (2 * np.sqrt(2 * np.log(2)))
-
-
-def load_sources(filename):
-    """
-    Open a file, read contents, return a list of all the sources in that file.
-    @param filename:
-    @return: list of OutputSource objects
-    """
-    catalog = catalogs.table_to_source_list(catalogs.load_table(filename))
-    logging.info("read {0} sources from {1}".format(len(catalog), filename))
-    return catalog
-
-
-def make_model(sources, shape, wcshelper, mask=False, frac=None, sigma=4):
-    """
-
-    @param sources: a list of AegeanTools.models.SimpleSource objects
-    @param shape: the shape of the input (and output) image
-    @param wcshelper: an AegeanTools.wcs_helpers.WCSHelper object corresponding to the input image
-    @param mask: If true then mask pixels instead of subtracting the sources
-    @param frac: pixels that are brighter than frac*peak_flux for each source will be masked if mask=True
-    @param sigma: pixels that are brighter than rms*sigma be masked if mask=True
-    @return:
-    """
-
-    # Model array
-    m = np.zeros(shape, dtype=np.float32)
-    factor = 5
-
-    i_count = 0
-    for src in sources:
-        xo, yo, sx, sy, theta = wcshelper.sky2pix_ellipse([src.ra, src.dec], src.a/3600, src.b/3600, src.pa)
-        phi = np.radians(theta)
-
-        # skip sources that have a center that is outside of the image
-        if not 0 < xo < shape[0]:
-            logging.debug("source {0} is not within image".format(src.island))
-            continue
-        if not 0 < yo < shape[1]:
-            logging.debug("source {0} is not within image".format(src.island))
-            continue
-
-        # pixels over which this model is calculated
-        xoff = factor*(abs(sx*np.cos(phi)) + abs(sy*np.sin(phi)))
-        xmin = xo - xoff
-        xmax = xo + xoff
-
-        yoff = factor*(abs(sx*np.sin(phi)) + abs(sy*np.cos(phi)))
-        ymin = yo - yoff
-        ymax = yo + yoff
-
-        # clip to the image size
-        ymin = max(np.floor(ymin), 0)
-        ymax = min(np.ceil(ymax), shape[1])
-
-        xmin = max(np.floor(xmin), 0)
-        xmax = min(np.ceil(xmax), shape[0])
-
-        if not np.all(np.isfinite([ymin, ymax, xmin, xmax])):
-            continue
-
-        if logging.getLogger().isEnabledFor(logging.DEBUG):
-            logging.debug("Source ({0},{1})".format(src.island, src.source))
-            logging.debug(" xo, yo: {0} {1}".format(xo, yo))
-            logging.debug(" sx, sy: {0} {1}".format(sx, sy))
-            logging.debug(" theta, phi: {0} {1}".format(theta, phi))
-            logging.debug(" xoff, yoff: {0} {1}".format(xoff, yoff))
-            logging.debug(" xmin, xmax, ymin, ymax: {0}:{1} {2}:{3}".format(xmin, xmax, ymin, ymax))
-            logging.debug(" flux, sx, sy: {0} {1} {2}".format(src.peak_flux, sx, sy))
-
-        # positions for which we want to make the model
-        x, y = np.mgrid[xmin:xmax, ymin:ymax]
-        x = map(int, x.ravel())
-        y = map(int, y.ravel())
-
-        # TODO: understand why xo/yo -1 is needed
-        model = fitting.elliptical_gaussian(x, y, src.peak_flux, xo-1, yo-1, sx*FWHM2CC, sy*FWHM2CC, theta)
-
-        # Mask the output image if requested
-        if mask:
-            if frac is not None:
-                indices = np.where(model >= (frac*src.peak_flux))
-            else:
-                indices = np.where(model >= (sigma*src.local_rms))
-            model[indices] = np.nan
-
-        m[x, y] += model
-        i_count += 1
-    logging.info("modeled {0} sources".format(i_count))
-    return m
-
-
-def make_residual(fitsfile, catalog, rfile, mfile=None, add=False, mask=False, frac=None, sigma=4):
-    """
-
-    @param fitsfile: Input fits image filename
-    @param catalog: Input catalog filename of a type supported by Aegean
-    @param rfile: Residual image filename
-    @param mfile: model image filename
-    @param add: add the model instead of subtracting it
-    @param mask: If true then mask pixels instead of subtracting the sources
-    @param frac: pixels that are brighter than frac*peak_flux for each source will be masked if mask=True
-    @return:
-    """
-    source_list = load_sources(catalog)
-    # force two axes so that we dump redundant stokes/freq axes if they are present.
-    hdulist = fits.open(fitsfile, naxis=2)
-    # ignore dimensions of length 1
-    data = np.squeeze(hdulist[0].data)
-    header = hdulist[0].header
-
-    wcshelper = wcs_helpers.WCSHelper.from_header(header)
-
-    model = make_model(source_list, data.shape, wcshelper, mask, frac, sigma)
-
-    if add or mask:
-        residual = data + model
-    else:
-        residual = data - model
-
-    hdulist[0].data = residual
-    hdulist.writeto(rfile, clobber=True)
-    logging.info("wrote residual to {0}".format(rfile))
-    if mfile is not None:
-        hdulist[0].data = model
-        hdulist.writeto(mfile, clobber=True)
-        logging.info("wrote model to {0}".format(mfile))
-    return
 
 
 if __name__ == "__main__":
@@ -175,6 +46,9 @@ if __name__ == "__main__":
     logging_level = logging.DEBUG if options.debug else logging.INFO
     logging.basicConfig(level=logging_level, format="%(process)d:%(levelname)s %(message)s")
     logging.info("This is AeRes {0}-({1})".format(__version__, __date__))
+    if len(args) < 1:
+        parser.print_help()
+        sys.exit(0)
     if options.catalog is None:
         logging.error("input catalog is required")
         sys.exit(1)

--- a/scripts/AeRes
+++ b/scripts/AeRes
@@ -46,17 +46,18 @@ if __name__ == "__main__":
     logging_level = logging.DEBUG if options.debug else logging.INFO
     logging.basicConfig(level=logging_level, format="%(process)d:%(levelname)s %(message)s")
     logging.info("This is AeRes {0}-({1})".format(__version__, __date__))
-    if len(args) < 1:
-        parser.print_help()
-        sys.exit(0)
+
     if options.catalog is None:
         logging.error("input catalog is required")
+        parser.print_help()
         sys.exit(1)
     if options.fitsfile is None:
         logging.error("input fits file is required")
+        parser.print_help()
         sys.exit(1)
     if options.rfile is None:
         logging.error("output residual filename is required")
+        parser.print_help()
         sys.exit(1)
 
     logging.info("Using {0} and {1} to make {2}".format(options.fitsfile, options.catalog, options.rfile))

--- a/tests/test_AerRes.py
+++ b/tests/test_AerRes.py
@@ -1,0 +1,89 @@
+#! /usr/bin/env python
+"""
+Test the AeRes module
+"""
+
+from __future__ import print_function
+
+__author__ = 'Paul Hancock'
+
+from AegeanTools import AeRes as ar
+from AegeanTools import wcs_helpers
+
+from astropy.io import fits
+import numpy as np
+import os
+
+
+def test_load_sources():
+    """Test load_sources"""
+    filename = 'tests/test_files/1904_comp.fits'
+    cat = ar.load_sources(filename)
+    if cat is None:
+        raise AssertionError("load_sources_failed")
+    return
+
+
+def test_make_model():
+    """Test make_modell"""
+    filename = 'tests/test_files/1904_comp.fits'
+    sources = ar.load_sources(filename)
+    hdulist = fits.open('tests/test_files/1904-66_SIN.fits')
+    wcs_helper = wcs_helpers.WCSHelper.from_header(header=hdulist[0].header)
+    # regular run
+    model = ar.make_model(sources=sources, shape=hdulist[0].data.shape,
+                          wcshelper=wcs_helper)
+    if np.all(model == 0.):
+        raise AssertionError("Model is empty")
+
+    # model with *all* sources outside region
+    # shape (100,2) means we only sometimes reject a source based on it's x-coord
+    model = ar.make_model(sources=sources, shape=(100, 2),
+                          wcshelper=wcs_helper)
+    if not np.all(model == 0.):
+        raise AssertionError("Model is *not* empty")
+
+    # test mask with sigma
+    model = ar.make_model(sources=sources, shape=hdulist[0].data.shape,
+                          wcshelper=wcs_helper, mask=True)
+    if np.all(model == 0.):
+        raise AssertionError("Model is empty")
+    if not np.any(np.isnan(model)):
+        raise AssertionError("Model is not masked")
+
+    # test mask with frac
+    model = ar.make_model(sources=sources, shape=hdulist[0].data.shape,
+                          wcshelper=wcs_helper, mask=True, frac=0.1)
+    if np.all(model == 0.):
+        raise AssertionError("Model is empty")
+    if not np.any(np.isnan(model)):
+        raise AssertionError("Model is not masked")
+
+
+def test_make_residual():
+    """Test make_residual"""
+    fitsfile = 'tests/test_files/1904-66_SIN.fits'
+    catalog = 'tests/test_files/1904_comp.fits'
+    residual = 'tests/temp/residual.fits'
+    masked = 'tests/temp/masked.fits'
+    # default operation
+    ar.make_residual(fitsfile=fitsfile, catalog=catalog,
+                     rfile=residual, mfile=masked, mask=False)
+    if not os.path.exists(masked):
+        raise AssertionError("Mask file not written")
+    os.remove(masked)
+
+    # with masking
+    ar.make_residual(fitsfile=fitsfile, catalog=catalog,
+                     rfile=residual, mfile=masked, mask=True)
+    if not os.path.exists(masked):
+        raise AssertionError("Mask file not written")
+    os.remove(masked)
+
+
+if __name__ == "__main__":
+    # introspect and run all the functions starting with 'test'
+    for f in dir():
+        if f.startswith('test'):
+            print(f)
+            globals()[f]()


### PR DESCRIPTION
After a bug report from Tom, I noticed that `AeRes` had no test suite.

I have moved the functionality from the script `AeRes` into a new module `AegeanToos/AeRes.py`. I have also created a test suite for this new module and addressed docstring/pep issues that were previously ignored.

Finally, I have fixed the bug that Tom noticed when running `AeRes` in python 3.