### PR TITLE
Correcting integrated flux density measurements*

### DIFF
--- a/AegeanTools/source_finder.py
+++ b/AegeanTools/source_finder.py
@@ -584,13 +584,13 @@ class SourceFinder(object):
                                                                        positions[1][0]))
 
             # integrated flux
-            beam_area = global_data.psfhelper.get_beamarea_deg2(source.ra, source.dec)  # beam in deg^2
-            # get_beamarea_pix(source.ra, source.dec)  # beam is in pix^2
+            beam_area_pix = global_data.psfhelper.get_beamarea_pix(source.ra, source.dec)
+            beam_area = global_data.psfhelper.get_beamarea_deg2(source.ra, source.dec)
             isize = source.pixels  # number of non zero pixels
             self.log.debug("- pixels used {0}".format(isize))
             source.int_flux = np.nansum(kappa_sigma)  # total flux Jy/beam
             self.log.debug("- sum of pixles {0}".format(source.int_flux))
-            source.int_flux *= beam_area  # total flux in Jy
+            source.int_flux *= (4.*np.log(2.) / beam_area_pix)  # total flux in Jy
             self.log.debug("- integrated flux {0}".format(source.int_flux))
             eta = erf(np.sqrt(-1 * np.log(abs(source.local_rms * outerclip / source.peak_flux)))) ** 2
             self.log.debug("- eta {0}".format(eta))

--- a/AegeanTools/wcs_helpers.py
+++ b/AegeanTools/wcs_helpers.py
@@ -614,7 +614,7 @@ class PSFHelper(WCSHelper):
             The area of the beam in square pixels.
         """
 
-	parea = abs(self.wcshelper.pixscale[0] * self.wcshelper.pixscale[1])  # in deg**2 at reference coords
+        parea = abs(self.wcshelper.pixscale[0] * self.wcshelper.pixscale[1])  # in deg**2 at reference coords
         barea = self.get_beamarea_deg2(ra, dec)
         return barea / parea
 

--- a/AegeanTools/wcs_helpers.py
+++ b/AegeanTools/wcs_helpers.py
@@ -613,10 +613,10 @@ class PSFHelper(WCSHelper):
         area : float
             The area of the beam in square pixels.
         """
-        beam = self.get_pixbeam(ra, dec)
-        if beam is None:
-            return 0
-        return beam.a * beam.b * np.pi
+
+	parea = abs(self.wcshelper.pixscale[0] * self.wcshelper.pixscale[1])  # in deg**2 at reference coords
+        barea = self.get_beamarea_deg2(ra, dec)
+        return barea / parea
 
     def get_beamarea_deg2(self, ra, dec):
 


### PR DESCRIPTION
Corrections to integrated flux density measurements for SIN-projected images, including general correction to island integrated flux density measurements. This largely removes calculation of projected beam size (hence beam area) in degrees^2, and assumes the beam area in pixels^2 remains constant; *this is valid for SIN projections and will work with a user-supplied PSF map. 

Further work will need to be done ensure other projections will be fine. 