### PR TITLE
Added a progress bar 

### DIFF
--- a/AegeanTools/source_finder.py
+++ b/AegeanTools/source_finder.py
@@ -14,6 +14,7 @@ import logging
 import logging.config
 import lmfit
 import scipy
+from tqdm import tqdm
 from scipy.special import erf
 from scipy.ndimage import label, find_objects
 from scipy.ndimage.filters import minimum_filter, maximum_filter
@@ -1784,7 +1785,7 @@ class SourceFinder(object):
     def find_sources_in_image(self, filename, hdu_index=0, outfile=None, rms=None, bkg=None, max_summits=None, innerclip=5,
                               outerclip=4, cores=None, rmsin=None, bkgin=None, beam=None, doislandflux=False,
                               nopositive=False, nonegative=False, mask=None, imgpsf=None, blank=False,
-                              docov=True, cube_index=None):
+                              docov=True, cube_index=None, progress=False):
         """
         Run the Aegean source finder.
 
@@ -1843,6 +1844,9 @@ class SourceFinder(object):
 
         cube_index : int
             For image cubes, cube_index determines which slice is used.
+
+        progress : bool
+            Produce a progress bar as islands are being fitted. (default=False)
 
         Returns
         -------
@@ -1924,7 +1928,7 @@ class SourceFinder(object):
             print(ComponentSource.header, file=outfile)
 
         sources = []
-        for srcs in queue:
+        for srcs in tqdm(queue, total=len(islands), desc='Fitted Islands', disable=not progress):
             if srcs:  # ignore empty lists
                 for src in srcs:
                     # ignore sources that we have been told to ignore

--- a/scripts/aegean
+++ b/scripts/aegean
@@ -81,7 +81,8 @@ if __name__ == "__main__":
                         help='DEPRECATED')
     group1.add_argument('--slice', dest='slice', type=int, default=None,
                         help='If the input data is a cube, then this slice will determine the array index of the image which will be processed by aegean')
-
+    group1.add_argument('--progress', default=False, action='store_true',
+                    help='Provide a progress bar as islands are being fitted. [default: False')
 
     # Input
     group2 = parser.add_argument_group("Input Options")
@@ -346,7 +347,7 @@ if __name__ == "__main__":
                                          doislandflux=options.doislandflux,
                                          nonegative=not options.negative, nopositive=options.nopositive,
                                          mask=options.region, imgpsf=options.imgpsf, blank=options.blank,
-                                         docov=options.docov, cube_index=options.slice)
+                                         docov=options.docov, cube_index=options.slice, progress=options.progress)
         if options.blank:
             outname = basename+'_blank.fits'
             sf.save_image(outname)

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ else:
     reqs.append('astropy>=2.0')
     reqs.append('healpy >=1.10')
     reqs.append('lmfit>=0.9.2')
+    reqs.append('tqdm>=4.0.0')
 
 data_dir = 'AegeanTools/data'
 


### PR DESCRIPTION
As a quick proof of concept, I added a quick progress bar to provide some indication on the state of aegean as it is fitting. It is fairly straightword using `tqdm`. An option has been added to either enable or disable this progress bar from appearing. At the moment it is not writing to the logger object -- rather it is just printing to stdout. I am not sure what you would prefer here. 