### PR TITLE
regroup eps option to aegean and unit fix

### DIFF
--- a/AegeanTools/source_finder.py
+++ b/AegeanTools/source_finder.py
@@ -2717,7 +2717,7 @@ class SourceFinder(object):
         # compute eps if it's not defined
         if regroup_eps is None:
             # s.a is in arcsec but we assume regroup_eps is in arcmin
-            regroup_eps = 4*np.mean([s.a*60 for s in sources])
+            regroup_eps = 4*np.mean([s.a/60 for s in sources])
         # convert regroup_eps into a value appropriate for a cartesian measure
         regroup_eps = np.sin(np.radians(regroup_eps/60))
         input_sources = sources

--- a/scripts/aegean
+++ b/scripts/aegean
@@ -149,6 +149,9 @@ if __name__ == "__main__":
     group5.add_argument('--catpsf', dest='catpsf', type=str, default=None,
                         help='A psf map corresponding to the input catalog. This will allow for the correct resizing of' +
                              ' sources when the catalog and image psfs differ.')
+    group5.add_argument('--regroup-eps', dest='regroup_eps', default=None, type=float,
+                        help='The size in arcminutes that is used to regroup nearby components into a ' +
+                            'a single set of components that will be solved for simultaneously')
 
 
     # Debug and extras
@@ -366,7 +369,7 @@ if __name__ == "__main__":
                                  stage=options.priorized, ratio=options.ratio, outerclip=options.outerclip,
                                  cores=options.cores, doregroup=options.regroup, docov=options.docov,
                                  cube_index=options.slice,
-                                 progress=options.progress)
+                                 progress=options.progress, regroup_eps=options.regroup_eps)
 
 
     sources = sf.sources


### PR DESCRIPTION
As discussed, this fixes a small arcsecond to arcminute error that can cause the DBSCAN separation metric to become negative. I have also added an option to aegean to allow a user to specify their desired separation distance, in arcminutes. 