### PR TITLE
BANE sigma clipping routine rejig

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,28 @@
 language: python
-dist: xenial
+
+jobs:
+  include:
+#    - name: 'Python on OSX'
+#      os: osx
+#      osx_image: xcode11.2
+#      language: shell
+    - name: "Python 3.6 on Ubuntu-Xenial"
+      os: linux
+      python: "3.6"
+      dist: xenial
+    - name: "Python 3.7 on Ubuntu-Xenial"
+      os: linux
+      python: "3.7"
+      dist: xenial
+
 cache: pip
-python:
-  - "3.6"
-  - "3.7"
+
 # command to install dependencies
 install:
-  - pip install .                       # for AegeanTools
-  - pip install coveralls               # for coverage
-  - pip install codacy-coverage         # for code quality
-  - pip install -r doc/requirements.txt # for sphinx documentation 
+  - pip3 install .                       # for AegeanTools
+  - pip3 install coveralls               # for coverage
+  - pip3 install codacy-coverage         # for code quality
+  - pip3 install -r doc/requirements.txt # for sphinx documentation 
 # command to run tests
 script:
   - coverage run setup.py test          # run tests

--- a/AegeanTools/BANE.py
+++ b/AegeanTools/BANE.py
@@ -50,7 +50,7 @@ def barrier(events, sid, kind='neighbour'):
     return
 
 
-def sigmaclip(arr, lo, hi, reps=20):
+def sigmaclip(arr, lo, hi, reps=10):
     """
     Perform sigma clipping on an array, ignoring non finite values.
 

--- a/AegeanTools/BANE.py
+++ b/AegeanTools/BANE.py
@@ -50,7 +50,7 @@ def barrier(events, sid, kind='neighbour'):
     return
 
 
-def sigmaclip(arr, lo, hi, reps=3):
+def sigmaclip(arr, lo, hi, reps=20):
     """
     Perform sigma clipping on an array, ignoring non finite values.
 
@@ -89,16 +89,25 @@ def sigmaclip(arr, lo, hi, reps=3):
 
     std = np.std(clipped)
     mean = np.mean(clipped)
-    for _ in range(int(reps)):
-        clipped = clipped[np.where(clipped > mean-std*lo)]
-        clipped = clipped[np.where(clipped < mean+std*hi)]
-        pstd = std
-        if len(clipped) < 1:
+    prev_valid = len(clipped)
+    for count in range(int(reps)):
+        mask = (clipped > mean-std*lo) & (clipped < mean+std*hi)
+        clipped = clipped[mask]
+
+        curr_valid = len(clipped)
+        logging.debug("{0} {1} {2}".format(count, prev_valid, curr_valid))
+        # Making sure some set of pixels are available
+        if curr_valid < 30: 
+            break
+        # No change in statistics if no change is noted
+        if prev_valid == curr_valid:
             break
         std = np.std(clipped)
         mean = np.mean(clipped)
-        if 2*abs(pstd-std)/(pstd+std) < 0.2:
-            break
+        prev_valid = curr_valid
+    else:
+        logging.debug("No stopping criteria was reached after {0} cycles".format(reps))
+
     return mean, std
 
 

--- a/AegeanTools/BANE.py
+++ b/AegeanTools/BANE.py
@@ -96,8 +96,7 @@ def sigmaclip(arr, lo, hi, reps=10):
 
         curr_valid = len(clipped)
         logging.debug("{0} {1} {2}".format(count, prev_valid, curr_valid))
-        # Making sure some set of pixels are available
-        if curr_valid < 30: 
+        if curr_valid < 1: 
             break
         # No change in statistics if no change is noted
         if prev_valid == curr_valid:

--- a/AegeanTools/source_finder.py
+++ b/AegeanTools/source_finder.py
@@ -2717,7 +2717,7 @@ class SourceFinder(object):
         # compute eps if it's not defined
         if regroup_eps is None:
             # s.a is in arcsec but we assume regroup_eps is in arcmin
-            regroup_eps = 4*np.mean([s.a*60 for s in sources])
+            regroup_eps = 4*np.mean([s.a/60 for s in sources])
         # convert regroup_eps into a value appropriate for a cartesian measure
         regroup_eps = np.sin(np.radians(regroup_eps/60))
         input_sources = sources

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,10 +31,10 @@ sys.path.insert(0, os.path.abspath('..'))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx.ext.autodoc',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.viewcode',
-    'numpydoc',
-    'myst_parser']
+              'sphinx.ext.mathjax',
+              'sphinx.ext.viewcode',
+              'numpydoc',
+              'myst_parser']
 
 # config numpydoc to not use autosummary
 numpydoc_show_class_members = False
@@ -46,8 +46,8 @@ templates_path = ['_templates']
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = {'.rst':'restructuredtext',
-                 '.md':'markdown'}
+source_suffix = {'.rst': 'restructuredtext',
+                 '.md': 'markdown'}
 
 # The master toctree document.
 master_doc = 'index'
@@ -159,6 +159,3 @@ texinfo_documents = [
      author, 'AegeanTools', 'One line description of project.',
      'Miscellaneous'),
 ]
-
-
-

--- a/scripts/aegean
+++ b/scripts/aegean
@@ -149,6 +149,9 @@ if __name__ == "__main__":
     group5.add_argument('--catpsf', dest='catpsf', type=str, default=None,
                         help='A psf map corresponding to the input catalog. This will allow for the correct resizing of' +
                              ' sources when the catalog and image psfs differ.')
+    group5.add_argument('--regroup-eps', dest='regroup_eps', default=None, type=float,
+                        help='The size in arcminutes that is used to regroup nearby components into a ' +
+                            'a single set of components that will be solved for simultaneously')
 
 
     # Debug and extras
@@ -366,7 +369,7 @@ if __name__ == "__main__":
                                  stage=options.priorized, ratio=options.ratio, outerclip=options.outerclip,
                                  cores=options.cores, doregroup=options.regroup, docov=options.docov,
                                  cube_index=options.slice,
-                                 progress=options.progress)
+                                 progress=options.progress, regroup_eps=options.regroup_eps)
 
 
     sources = sf.sources


### PR DESCRIPTION
As discussed, we noticed some of the noise distributions of some residual images produce by `AegeanTools` had some deviations from a normal distribution. Some experimentation pointed us towards the original background and RMS maps produced by BANE. It seems like in some cases emission from real sources are not completely flagged out during the sigma clipping process when deriving the standard deviation and mean statistics. 

This patch does two main things:
- Increases the maximum cycle to 10 from 3
- Adjusts the early stopping criteria, relying on no change in the number of pixels being used to calculate the statistics 

Also some extra logging. Attached is a simple screen cap of the original BANE sigma clip routines, and those from this commit. 

![image](https://user-images.githubusercontent.com/10543142/141043671-a1938e32-fa85-4a3b-b8a3-202c54a6b647.png)
