### PR TITLE
Fourier-domain BANE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist/
 wiki/
 doc/_build/
 .vscode
+AegeanTools/__pycache__

--- a/AegeanTools/BANE_fft.py
+++ b/AegeanTools/BANE_fft.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+BANE: Background and Noise Estimation
+...but with FFTs
+"""
+
+from pathlib import Path
+from typing import Tuple, List
+import os
+from time import time
+import logging
+
+import numba as nb
+import numpy as np
+from astropy.convolution import Tophat2DKernel
+from astropy.io import fits
+from astropy.wcs import WCS
+from spectral_cube import StokesSpectralCube
+from spectral_cube.utils import FITSReadError
+
+from AegeanTools import BANE as bane
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+logger.addHandler(ch)
+
+@nb.njit(
+    nb.float32[:, :](nb.float32[:, :], nb.complex64[:, :], nb.float32),
+    fastmath=True,
+    parallel=True,
+)
+def fft_average(
+    image: np.ndarray, kernel_fft: np.ndarray, kern_sum: float
+) -> np.ndarray:
+    """Compute an average with FFT magic
+
+    Args:
+        image (np.ndarray): 2D image to average spatially
+        kernel_fft (np.ndarray): 2D kernel in Fourier space
+        kern_sum (float): Sum of the kernel in image space
+
+    Returns:
+        np.ndarray: Averaged image
+    """
+    image_fft = np.fft.rfft2(image)
+
+    smooth_fft = image_fft * kernel_fft
+
+    smooth = np.fft.irfft2(smooth_fft) / kern_sum
+    return smooth
+
+
+@nb.njit(
+    nb.types.UniTuple(
+        nb.float32[:, :],
+        2
+    )(nb.float32[:, :], nb.complex64[:, :], nb.float32),
+    fastmath=True,
+    parallel=True,
+)
+def bane_fft(
+    image: np.ndarray,
+    kernel_fft: np.ndarray,
+    kern_sum: float,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """BANE but with FFTs
+
+    Args:
+        image (np.ndarray): Image to find background and RMS of
+        kernel_fft (np.ndarray): Tophat kernel in Fourier domain
+        kern_sum (float): Sum of the kernel in image domain
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: Mean and RMS of the image
+    """
+    mean = fft_average(image, kernel_fft, kern_sum)
+    rms = np.sqrt((image - mean) ** 2)
+    avg_rms = fft_average(rms, kernel_fft, kern_sum)
+    return mean, avg_rms
+
+
+@nb.njit(
+    fastmath=True,
+    # parallel=True,
+)
+def _ft_kernel(kernel: np.ndarray, shape: tuple) -> np.ndarray:
+    """Compute the Fourier transform of a kernel
+
+    Args:
+        kernel (np.ndarray): 2D kernel
+        shape (tuple): Shape of the image
+
+    Returns:
+        np.ndarray: FFT of the kernel
+    """
+    return np.fft.rfft2(kernel, s=shape)
+
+
+def get_kernel(header: fits.Header) -> Tuple[np.ndarray, float]:
+    """Get the kernel for FFT BANE
+
+    Args:
+        header (fits.Header): Header of the image
+
+    Returns:
+        Tuple[np.ndarray, float]: FFT of the kernel and sum of the kernel
+    """
+    step_size = bane.get_step_size(header)
+    kernel = Tophat2DKernel(radius=step_size[0] // 2 * 5).array.astype(np.float32)
+    kernel /= kernel.max()
+    wcs = WCS(header)
+
+    kernel_fft = _ft_kernel(kernel, shape=wcs.celestial.array_shape)
+    kern_sum = kernel.sum()
+
+    return kernel_fft, kern_sum
+
+
+def robust_bane(
+    image: np.ndarray, header: fits.Header
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Two-round BANE with FFTs
+
+    Args:
+        image (np.ndarray): Image to find background and RMS of
+        header (fits.Header): Header of the image
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: Mean and RMS of the image
+    """
+    logger.info("Running FFT BANE")
+    tick = time()
+    # Setups
+    kernel_fft, kern_sum = get_kernel(header)
+    nan_mask = ~np.isfinite(image)
+    image = np.nan_to_num(image)
+
+    # Round 1
+    mean, avg_rms = bane_fft(image, kernel_fft, kern_sum)
+    # Round 2
+    # Repeat with masked values filled in with noise
+    snr = np.abs(image) / avg_rms
+    mask = snr > 5
+    image_masked = image.copy()
+    image_masked[mask] = np.random.normal(
+        loc=0, scale=avg_rms.mean(), size=image_masked[mask].shape
+    )
+    # image_masked = inpaint.inpaint_biharmonic(image, mask)
+    mean, avg_rms = bane_fft(image_masked, kernel_fft, kern_sum)
+
+    # Reapply mask
+    mean[nan_mask] = np.nan
+    avg_rms[nan_mask] = np.nan
+
+    tock = time()
+
+    logger.info(f"FFT BANE took {tock - tick:.2f} seconds")
+
+    return mean, avg_rms
+
+def init_outputs(
+    fits_file: Path,
+    ext: int = 0,
+) -> List[Path]:
+    """Initialize the output files
+
+    Args:
+        fits_file (Path): Input FITS file
+        ext (int, optional): HDU extension. Defaults to 0.
+    """    
+    logger.info("Initializing output files")
+    out_files: List[Path] = []
+    with fits.open(fits_file, memmap=True, mode="denywrite") as hdul:
+        header = hdul[ext].header
+    # Create an arbitrarly large file without holding it in memory
+    for suffix in ("rms", "bkg"):
+        out_file = Path(fits_file.as_posix().replace(".fits", f"_{suffix}.fits"))
+        if out_file.exists():
+            os.remove(out_file)
+
+        header.tofile(out_file)
+        shape = tuple(
+            header[f"NAXIS{ii}"] for ii in range(1, header["NAXIS"] + 1)
+        )
+        with open(out_file, "rb+") as fobj:
+            fobj.seek(
+                len(header.tostring())
+                + (np.prod(shape) * np.abs(header["BITPIX"] // 8))
+                - 1
+            )
+            fobj.write(b"\0")
+
+        logger.info(f"Created {out_file}")
+        out_files.append(out_file)
+
+    return out_files
+
+def write_outputs(
+        out_files: List[Path],
+        mean: np.ndarray,
+        rms: np.ndarray,
+):
+    rms_file, bkg_file = out_files
+    with fits.open(rms_file, memmap=True, mode="update") as hdul:
+        logger.info(f"Writing RMS to {rms_file}")
+        hdul[0].data = rms
+        hdul.flush()
+    logger.info(f"Wrote RMS to {rms_file}")
+
+    with fits.open(bkg_file, memmap=True, mode="update") as hdul:
+        logger.info(f"Writing background to {bkg_file}")
+        hdul[0].data = mean
+        hdul.flush()
+    logger.info(f"Wrote background to {bkg_file}")
+
+
+def main(
+    fits_file: Path,
+    ext: int = 0,
+) -> Tuple[np.ndarray, np.ndarray]:
+    # Init output files
+    out_files = init_outputs(fits_file, ext=ext)
+    # Check for frequency axis and Stokes axis
+    try:
+        cube = StokesSpectralCube.read(fits_file)
+        is_stokes_cube = len(cube.shape) > 3 and cube.shape[-1] > 1
+        if is_stokes_cube:
+            logger.info("Detected Stokes cube")
+            raise NotImplementedError("Stokes cube not implemented")
+        
+    except FITSReadError:
+        logger.info("Input FITS file is an image")
+        with fits.open(fits_file, memmap=True, mode="denywrite") as hdul:
+            image = hdul[ext].data.astype(np.float32)
+            header = hdul[ext].header
+        
+        assert len(image.shape) == 2, "Input image must be 2D"
+
+        logger.info(f"Running BANE on image ({image.shape})")
+
+        # Run BANE
+        bkg, rms = robust_bane(image, header)
+
+    finally:
+        # Write output
+        write_outputs(out_files, bkg, rms)
+
+        logger.info("Done")
+
+    return bkg, rms
+
+def cli():
+    import argparse
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+    )
+    parser.add_argument(
+        "fits_file",
+        type=str,
+        help="Input FITS file",
+    )
+    parser.add_argument(
+        "--ext",
+        type=int,
+        default=0,
+        help="HDU extension",
+    )
+    args = parser.parse_args()
+
+    _ = main(
+        Path(args.fits_file),
+        ext=args.ext,
+    )
+
+    return 0
+
+if __name__ == "__main__":
+    cli()

--- a/AegeanTools/BANE_fft.py
+++ b/AegeanTools/BANE_fft.py
@@ -416,8 +416,10 @@ def robust_bane(
     mean, avg_rms = bane_fft(image_ds, kernel, kern_sum)
 
     # Upsample the mean and RMS to the original image size
-    mean_us = ndimage.shift(ndimage.zoom(mean, zoom, order=3, grid_mode=True), step_size*2)
-    avg_rms_us = ndimage.shift(ndimage.zoom(avg_rms, zoom, order=3, grid_mode=True), step_size*2)
+    mean_shift = ndimage.shift(mean, -box_size)
+    avg_rms_shift = ndimage.shift(avg_rms, -box_size)
+    mean_us = ndimage.zoom(mean_shift, zoom, order=3, grid_mode=True)
+    avg_rms_us = ndimage.zoom(avg_rms_shift, zoom, order=3, grid_mode=True)
 
     # Reapply mask
     mean_us[nan_mask] = np.nan

--- a/AegeanTools/BANE_fft.py
+++ b/AegeanTools/BANE_fft.py
@@ -425,8 +425,8 @@ def robust_bane(
     avg_rms_us = ndimage.zoom(avg_rms, zoom, order=3, grid_mode=True)
 
     # Reapply mask
-    # mean_us[nan_mask] = np.nan
-    # avg_rms_us[nan_mask] = np.nan
+    mean_us[nan_mask] = np.nan
+    avg_rms_us[nan_mask] = np.nan
 
     tock = time()
 

--- a/AegeanTools/BANE_fft.py
+++ b/AegeanTools/BANE_fft.py
@@ -197,7 +197,6 @@ def get_kernel(
 
     if not box_size or box_size < 0:
         # Box size
-        logging.info(f"Using step size of {step_size} pixels")
         npix_box = 10 if not box_size else abs(box_size)
         logging.info(f"Using a box size of {npix_box} per beam")
         box_size = int(np.ceil(pix_per_beam * npix_box / step_size))
@@ -391,12 +390,12 @@ def robust_bane(
     divx, modx = divmod(stop_x, step_size)
     divy, mody = divmod(stop_y, step_size)
 
-    while (divx + 1) % 2 != 0:
-        stop_x -= modx
+    while divx % 2 != 0:
+        stop_x -= 1
         divx, modx = divmod(stop_x, step_size)
 
-    while (divy + 1) % 2 != 0:
-        stop_y -= mody
+    while divy % 2 != 0:
+        stop_y -= 1
         divy, mody = divmod(stop_y, step_size)
 
     x_slice = slice(start_idx, stop_x, step_size)
@@ -417,8 +416,8 @@ def robust_bane(
     mean, avg_rms = bane_fft(image_ds, kernel, kern_sum)
 
     # Upsample the mean and RMS to the original image size
-    mean_us = ndimage.zoom(mean, zoom, order=3, grid_mode=True)
-    avg_rms_us = ndimage.zoom(avg_rms, zoom, order=3, grid_mode=True)
+    mean_us = ndimage.shift(ndimage.zoom(mean, zoom, order=3, grid_mode=True), step_size*2)
+    avg_rms_us = ndimage.shift(ndimage.zoom(avg_rms, zoom, order=3, grid_mode=True), step_size*2)
 
     # Reapply mask
     mean_us[nan_mask] = np.nan

--- a/AegeanTools/BANE_fft.py
+++ b/AegeanTools/BANE_fft.py
@@ -5,6 +5,8 @@ BANE: Background and Noise Estimation
 ...but with FFTs
 """
 
+# TODO: Images come out with a slight offset. Need to figure out why.
+
 __author__ = ["Alec Thomson", "Tim Galvin"]
 __version__ = "0.0.0"
 

--- a/AegeanTools/BANE_fft.py
+++ b/AegeanTools/BANE_fft.py
@@ -5,6 +5,9 @@ BANE: Background and Noise Estimation
 ...but with FFTs
 """
 
+__author__ = ["Alec Thomson", "Tim Galvin"]
+__version__ = "0.0.0"
+
 import os
 import multiprocessing as mp
 from pathlib import Path
@@ -210,12 +213,11 @@ def chunk_image(image_shape: Tuple[int, int], box_size: int) -> np.ndarray:
 
 @nb.njit(
     nb.float32(
-        nb.float32[:, :],
+        nb.float32[:],
         nb.types.unicode_type,
         nb.int32,
         nb.float32,
         nb.float32,
-        nb.boolean,
     ),
     cache=True,
 )
@@ -231,7 +233,7 @@ def estimate_rms(
     pixel distribution histogram, with the standard deviation being return. 
     
     Arguments:
-        data (np.ndarray) -- Data to estimate the noise level of
+        data (np.ndarray) -- 1D data to estimate the noise level of
     
     Keyword Arguments:
         mode (str) -- Clipping mode used to flag outlying pixels, either made on the median absolute deviation (`mad`) or standard deviation (`std`) (default: ('mad'))
@@ -312,7 +314,7 @@ def robust_bane(
 
     # Quick and dirty rms estimate
     rms_est = estimate_rms(
-        data=image_mask,
+        data=image_mask.flatten(),
         mode="mad",
         clip_rounds=2,
         bin_perc=0.25,
@@ -629,6 +631,12 @@ def cli():
         type=int,
         default=None,
         help="Number of cores to use (only sppeds up cube processing). Default is all cores.",
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
     )
     args = parser.parse_args()
 

--- a/AegeanTools/BANE_fft.py
+++ b/AegeanTools/BANE_fft.py
@@ -413,23 +413,9 @@ def robust_bane(
     zoom_y = image.shape[0] / image_ds.shape[0]
     zoom = (zoom_y, zoom_x)
 
-    # Round 1
+    # Run the FFT
     mean, avg_rms = bane_fft(image_ds, kernel, kern_sum)
 
-    """
-    # Round 2
-    # Repeat with masked values filled in with noise
-    snr = np.abs(image_mask) / np.nanmedian(avg_rms)
-    mask = snr > 5
-    image_masked = image_mask.copy()
-    # Fill sources with noise
-    image_masked[mask] = np.random.normal(
-        loc=0, scale=avg_rms.mean(), size=image_masked[mask].shape
-    )
-    # Downsample the masked image
-    image_masked_ds = image_masked[(y_slice, x_slice)]
-    mean_masked, avg_rms_masked = bane_fft(image_masked_ds, kernel, kern_sum)
-    """
     # Upsample the mean and RMS to the original image size
     mean_us = ndimage.zoom(mean, zoom, order=3, grid_mode=True)
     avg_rms_us = ndimage.zoom(avg_rms, zoom, order=3, grid_mode=True)

--- a/AegeanTools/BANE_fft.py
+++ b/AegeanTools/BANE_fft.py
@@ -423,8 +423,8 @@ def robust_bane(
     avg_rms_us = ndimage.zoom(avg_rms, zoom, order=3, grid_mode=True)
 
     # Reapply mask
-    mean_us[nan_mask] = np.nan
-    avg_rms_us[nan_mask] = np.nan
+    # mean_us[nan_mask] = np.nan
+    # avg_rms_us[nan_mask] = np.nan
 
     tock = time()
 

--- a/AegeanTools/BANE_fft.py
+++ b/AegeanTools/BANE_fft.py
@@ -416,10 +416,11 @@ def robust_bane(
     mean, avg_rms = bane_fft(image_ds, kernel, kern_sum)
 
     # Upsample the mean and RMS to the original image size
-    mean_shift = ndimage.shift(mean, -box_size)
-    avg_rms_shift = ndimage.shift(avg_rms, -box_size)
-    mean_us = ndimage.zoom(mean_shift, zoom, order=3, grid_mode=True)
-    avg_rms_us = ndimage.zoom(avg_rms_shift, zoom, order=3, grid_mode=True)
+    # Trying a shift first to see if it helps with the edge effects
+    # mean_shift = ndimage.shift(mean, box_size*step_size)
+    # avg_rms_shift = ndimage.shift(avg_rms, box_size*step_size)
+    mean_us = ndimage.zoom(mean, zoom, order=3, grid_mode=True)
+    avg_rms_us = ndimage.zoom(avg_rms, zoom, order=3, grid_mode=True)
 
     # Reapply mask
     mean_us[nan_mask] = np.nan

--- a/AegeanTools/BANE_fft.py
+++ b/AegeanTools/BANE_fft.py
@@ -119,6 +119,7 @@ def tophat_kernel(diameter: int):
     kernel[mask] = 1
     return kernel
 
+
 def gaussian_kernel(fwhm: int) -> np.ndarray:
     """Make a Gaussian kernel
 
@@ -186,7 +187,7 @@ def get_kernel(
             raise ValueError(
                 "Could not parse beam from header - try specifying step size"
             )
-        
+
     if not step_size or step_size < 0:
         # Step size
         npix_step = 3 if not step_size else abs(step_size)
@@ -362,8 +363,8 @@ def robust_bane(
     tick = time()
     # Setups
     kernel, kern_sum, step_size = get_kernel(
-        header=header, 
-        step_size=step_size, 
+        header=header,
+        step_size=step_size,
         box_size=box_size,
         kernel_func=kernel_func,
     )
@@ -398,12 +399,8 @@ def robust_bane(
         stop_y -= mody
         divy, mody = divmod(stop_y, step_size)
 
-    x_slice = slice(
-        start_idx, stop_x, step_size
-    )
-    y_slice = slice(
-        start_idx, stop_y, step_size
-    )
+    x_slice = slice(start_idx, stop_x, step_size)
+    y_slice = slice(start_idx, stop_y, step_size)
     image_ds = image_mask[(y_slice, x_slice)]
     logging.info(f"Downsampled image to {image_ds.shape}")
     for i in range(2):
@@ -515,12 +512,12 @@ def bane_2d(
     logging.info(f"Running BANE on image {image.shape}")
     # Run BANE
     bkg, rms = robust_bane(
-        image.astype(np.float32), 
-        header, 
-        step_size=step_size, 
+        image.astype(np.float32),
+        header,
+        step_size=step_size,
         box_size=box_size,
         kernel_func=kernel_func,
-        rms_estimator=rms_estimator
+        rms_estimator=rms_estimator,
     )
     write_outputs(out_files, bkg, rms)
 
@@ -546,12 +543,12 @@ def bane_3d_loop(
         bkg = bkg_hdul[ext].data
         logging.info(f"Running BANE on plane {idx}")
         bkg[idx], rms[idx] = robust_bane(
-            plane.astype(np.float32), 
-            header, 
-            step_size=step_size, 
-            box_size=box_size, 
+            plane.astype(np.float32),
+            header,
+            step_size=step_size,
+            box_size=box_size,
             kernel_func=kernel_func,
-            rms_estimator=rms_estimator
+            rms_estimator=rms_estimator,
         )
         rms_hdul.flush()
         bkg_hdul.flush()
@@ -578,13 +575,13 @@ def bane_3d(
             bane_3d_loop,
             [
                 (
-                    cube[ii], 
-                    ii, 
-                    header, 
-                    out_files, 
-                    ext, 
-                    step_size, 
-                    box_size, 
+                    cube[ii],
+                    ii,
+                    header,
+                    out_files,
+                    ext,
+                    step_size,
+                    box_size,
                     kernel_func,
                     rms_estimator,
                 )
@@ -702,10 +699,10 @@ def main(
     else:
         logging.info("Detected 2D image")
         bkg, rms = bane_2d(
-            image=data, 
-            header=header, 
-            out_files=out_files, 
-            step_size=step_size, 
+            image=data,
+            header=header,
+            out_files=out_files,
+            step_size=step_size,
             box_size=box_size,
             kernel_func=kernels.get(kernel_str, gaussian_kernel),
             rms_estimator=estimators.get(estimator_str, mad_std),

--- a/AegeanTools/numba_polyfit.py
+++ b/AegeanTools/numba_polyfit.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Numpy polyfit using numba."""
+# From https://gist.github.com/kadereub/9eae9cff356bb62cdbd672931e8e5ec4
+# kadereub/numba_polyfit.py
+__author__ = "kadereub"
+# Load relevant libraries
+import numpy as np
+import numba as nb
+import matplotlib.pyplot as plt
+
+# Goal is to implement a numba compatible polyfit (note does not include error handling)
+
+# Define Functions Using Numba
+# Idea here is to solve ax = b, using least squares, where a represents our coefficients e.g. x**2, x, constants
+@nb.njit("f8[:,:](f8[:], i8)")
+def _coeff_mat(x, deg):
+    mat_ = np.zeros(shape=(x.shape[0],deg + 1), dtype=np.float64)
+    const = np.ones_like(x)
+    mat_[:,0] = const
+    mat_[:, 1] = x
+    if deg > 1:
+        for n in range(2, deg + 1):
+            mat_[:, n] = x**n
+    return mat_
+
+@nb.njit("f8[:](f8[:,:], f8[:])")
+def _fit_x(a, b):
+    # linalg solves ax = b
+    det_ = np.linalg.lstsq(a, b)[0]
+    return det_
+
+@nb.njit("f8[:](f8[:], f8[:], i8)")
+def fit_poly(x, y, deg):
+    a = _coeff_mat(x, deg)
+    p = _fit_x(a, y)
+    # Reverse order so p[0] is coefficient of highest order
+    return p[::-1]
+
+@nb.njit()
+def eval_polynomial(P, x):
+    '''
+    Compute polynomial P(x) where P is a vector of coefficients, highest
+    order coefficient at P[0].  Uses Horner's Method.
+    '''
+    result = 0
+    for coeff in P:
+        result = x * result + coeff
+    return result
+
+if __name__ == "__main__":
+    # Do a demo
+    # Create Dummy Data and use existing numpy polyfit as test
+    x = np.linspace(0, 2, 20)   
+    y = np.cos(x) + 0.3*np.random.rand(20)
+    p = np.poly1d(np.polyfit(x, y, 3))
+
+    t = np.linspace(0, 2, 200)
+    plt.plot(x, y, 'o', t, p(t), '-')
+
+    # Now plot using the Numba (amazing) functions
+    p_coeffs = fit_poly(x, y, deg=3)
+    plt.plot(x, y, 'o', t, eval_polynomial(p_coeffs, t), '-')
+
+    # Great Success...
+
+# References
+# 1. Numpy least squares docs -> https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.lstsq.html#numpy.linalg.lstsq
+# 2. Numba linear alegbra supported funcs -> https://numba.pydata.org/numba-doc/dev/reference/numpysupported.html#linear-algebra
+# 3. SO Post -> https://stackoverflow.com/questions/56181712/fitting-a-quadratic-function-in-python-without-numpy-polyfit

--- a/scripts/BANE_fft
+++ b/scripts/BANE_fft
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import sys
+from AegeanTools import BANE_fft
+
+if __name__ == "__main__":
+    sys.exit(BANE_fft.cli())

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     install_requires=reqs,
     scripts=['scripts/aegean', 'scripts/BANE',
              'scripts/SR6', 'scripts/AeRes', 'scripts/MIMAS',
-             'scripts/AeReg', 'scripts/fix_beam.py'],
+             'scripts/AeReg', 'scripts/fix_beam.py', 'scripts/BANE_fft'],
     data_files=[('AegeanTools', [os.path.join(data_dir, 'MOC.fits')])],
     python_requires='>=3.8',
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
Hi @PaulHancock,

@tjgalvin and I have been experimenting with using a Fourier approach for BANE. The motivation for this was to boost the speed, especially when running on large cubes (such as those produced for polarisation products). We were also inspired by the Fourier approach used by WSClean for background/noise estimation.

I've put together a performant script that uses Numba for some very nice speed ups. This approach can blast through large cubes in short order. I've also added some options for handling 3D and 4D cubes which might be useful for regular BANE too.

The last outstanding issue is that is seems that output images are offset up and right by the size of the convolution kernel (a.k.a box size). I'll need to do some deeper digging to figure out how to fix that. In the meantime if you have any thoughts on that, please let me know!

Anyway, I'd be really keen to get your thoughts on this kind of approach :) 