### PR TITLE
use shorter sharemem filename to avoid #200 / #203

### DIFF
--- a/AegeanTools/BANE.py
+++ b/AegeanTools/BANE.py
@@ -8,6 +8,7 @@ The function filter_image should be imported from elsewhere and run as is.
 import copy
 import multiprocessing
 import os
+import platform
 import sys
 import uuid
 from multiprocessing.shared_memory import SharedMemory
@@ -366,7 +367,9 @@ def filter_mc_sharemem(filename, step_size, box_size, cores, shape,
     exit = False
     try:
         global memory_id
-        memory_id = str(uuid.uuid4())[:24]  # Some python installs on OSX limit filenames to 32 chars
+        memory_id = str(uuid.uuid4())
+        if 'Darwin' in platform.system():  # Some python installs on OSX limit filenames to 32 chars
+            memory_id = memory_id[:23]
         nbytes = np.prod(shape) * np.float64(1).nbytes
         ibkg = SharedMemory(name=f'ibkg_{memory_id}', create=True, size=nbytes)
         irms = SharedMemory(name=f'irms_{memory_id}', create=True, size=nbytes)

--- a/AegeanTools/BANE.py
+++ b/AegeanTools/BANE.py
@@ -366,7 +366,7 @@ def filter_mc_sharemem(filename, step_size, box_size, cores, shape,
     exit = False
     try:
         global memory_id
-        memory_id = str(uuid.uuid4())
+        memory_id = str(uuid.uuid4())[:24]  # Some python installs on OSX limit filenames to 32 chars
         nbytes = np.prod(shape) * np.float64(1).nbytes
         ibkg = SharedMemory(name=f'ibkg_{memory_id}', create=True, size=nbytes)
         irms = SharedMemory(name=f'irms_{memory_id}', create=True, size=nbytes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Jan 23 2024
+BANE
+- Fix bugs #200/#203 which stopped BANE from working on some OSX installs
+
 ### Jan 12 2024
 
 General


### PR DESCRIPTION
Seemingly simple fix to avoid issues #200 and #203 -> use shorter filenames for the shared memory.