### PR TITLE
Different rms/bkg modes, adaptive box size, rejig

### DIFF
--- a/AegeanTools/BANE.py
+++ b/AegeanTools/BANE.py
@@ -133,10 +133,13 @@ def adaptive_box_estimate(
         
         result = mode.perform(data=new)
     
-        if result.valid_pixels > 0.8 * original_pixels or loop > max_loop:
+        if loop >= max_loop:
+            break
+        if all(np.isfinite(result))  and result.valid_pixels > 0.9 * len(new):
             break
         
         loop += 1
+        print(f"increasing, {loop=} {row=} {column=}")
         
     
     rms = result.rms
@@ -402,6 +405,7 @@ def filter_mc_sharemem(filename, step_size, box_size, cores, shape,
     mode: ClippingModes = BANE_MODE_MAPPINGS[mode.lower()](**mode_kwargs)
 
     adaptive_loop = 5 if adaptive_box else 0
+    logging.info(f"Adaptive box resize loops: {adaptive_loop}")
 
     args = []
     for region in zip(ymins, ymaxs):

--- a/AegeanTools/BANE.py
+++ b/AegeanTools/BANE.py
@@ -91,6 +91,33 @@ def box(r, c, data_shape, box_size):
 def adaptive_box_estimate(
     data: np.ndarray, row: int, column: int, box_size, mode: ClippingModes, max_loop: int = 5
 ) -> Tuple[float,float]:
+    """Estimate the background and RMS level within a data extract. Multiple
+    clipping and noise estimation modes are supported. 
+    
+    The adaptive behavour is only activated should the pixel statistics become
+    compromised. At the moment, this only is considered true if fewer than 80percent
+    of the pixels remain after clipping. 
+
+    Parameters
+    ----------
+    data : np.ndarray
+        Data that will be the source of the box extraction
+    row : int
+        Row to center extracted region at
+    column : int
+        Column to center extracted region at
+    box_size : Tuple[int,int]
+        Base size of the box to extract
+    mode : ClippingModes
+        Instance of a clipping and noise estiamtion mode to use. Should return a BANEResult and ahve a .perform method. 
+    max_loop : int, optional
+        Maximum number of adjustable boxes to use. Will increase in steps of 100 pixels. If 0 adative mode is disabled, by default 5
+
+    Returns
+    -------
+    Tuple[float,float]
+        Backgrounf and noise estimation
+    """
     
     
     original_box = box_size

--- a/AegeanTools/BANE.py
+++ b/AegeanTools/BANE.py
@@ -106,6 +106,9 @@ def adaptive_box_estimate(data, row, column, box_size, mode: ClippingModes):
     else:
         raise TypeError(f"Unrecognised type, {mode=}")
     
+    if not np.isfinite(bkg) and not np.isfinite(rms):
+        raise ValueError("Nasty nan")
+    
     return float(bkg), float(rms)
         
         # while attempt < 10 and np.isnan(rms):

--- a/AegeanTools/CLI/BANE.py
+++ b/AegeanTools/CLI/BANE.py
@@ -50,6 +50,14 @@ def main(argv=()):
     parser.set_defaults(out_base=None, step_size=None, box_size=None,
                         twopass=True, cores=None, usescipy=False, debug=False)
 
+    group1.add_argument(
+        '--mode', 
+        type=str, 
+        choices=BANE.AVAILABLE_MODES,
+        default='sigmaclip', 
+        help=f"Which bkg and rms estimation mode to use. Available are: {BANE.AVAILABLE_MODES}"
+    )
+
     options = parser.parse_args(args=argv)
 
     if options.cite:
@@ -89,5 +97,6 @@ def main(argv=()):
                       box_size=options.box_size, cores=options.cores,
                       mask=options.mask, compressed=options.compress,
                       nslice=options.stripes,
-                      cube_index=options.cube_index)
+                      cube_index=options.cube_index,
+                      mode=options.mode)
     return 0

--- a/AegeanTools/CLI/BANE.py
+++ b/AegeanTools/CLI/BANE.py
@@ -105,5 +105,5 @@ def main(argv=()):
                       nslice=options.stripes,
                       cube_index=options.cube_index,
                       mode=options.mode,
-                      adapative_box=opts.adaptive_box)
+                      adaptive_box=options.adaptive_box)
     return 0

--- a/AegeanTools/CLI/BANE.py
+++ b/AegeanTools/CLI/BANE.py
@@ -57,6 +57,12 @@ def main(argv=()):
         default='sigmaclip', 
         help=f"Which bkg and rms estimation mode to use. Available are: {BANE.AVAILABLE_MODES}"
     )
+    group1.add_argument(
+        "--adaptive-box",
+        default=False,
+        action='store_true',
+        help="Allow the box-car to be resized should insufficent statistics be detected. "
+    )
 
     options = parser.parse_args(args=argv)
 
@@ -98,5 +104,6 @@ def main(argv=()):
                       mask=options.mask, compressed=options.compress,
                       nslice=options.stripes,
                       cube_index=options.cube_index,
-                      mode=options.mode)
+                      mode=options.mode,
+                      adapative_box=opts.adaptive_box)
     return 0

--- a/AegeanTools/sigma.py
+++ b/AegeanTools/sigma.py
@@ -26,6 +26,7 @@ class FittedSigmaClip(NamedTuple):
         return fitted_sigma_clip(data=data, sigma=self.sigma)
         
 def fitted_mean(data: np.ndarray, axis: Optional[int] =None) -> float:
+    """Internal function that returns the mean by fitting to pixel distribution data"""
     if axis is not None:
         # This is to make astropy sigma clip happy
         raise NotImplementedError("Unexpected axis keyword. ")
@@ -36,6 +37,7 @@ def fitted_mean(data: np.ndarray, axis: Optional[int] =None) -> float:
 
 
 def fitted_std(data: np.ndarray, axis: Optional[int]=None) -> float:
+    """Internal function that retunrs the stf by fitting to the pixel distribution"""
     if axis is not None:
         # This is to make astropy sigma clip happy
         raise NotImplementedError("Unexpected axis keyword. ")
@@ -45,7 +47,21 @@ def fitted_std(data: np.ndarray, axis: Optional[int]=None) -> float:
     return std
 
 def fitted_sigma_clip(data: np.ndarray, sigma: int=3) -> BANEResult:
-    
+    """Estimate the back ground and noise level by fitting to the pixel distribution. 
+    Sigma clipping is performed using the fitted statistics. 
+
+    Parameters
+    ----------
+    data : np.ndarray
+        Data that will be considered
+    sigma : int, optional
+        Threshold for a point to be flagged, by default 3
+
+    Returns
+    -------
+    BANEResult
+        RMS and bkg ground statistics
+    """
     data = data[np.isfinite(data)]
     
     clipped_plane = sigma_clip(
@@ -74,6 +90,9 @@ class FitBkgRmsEstimate(NamedTuple):
         return fit_bkg_rms_estimate(data=data, clip_rounds=self.clip_rounds, bin_perc=self.bin_perc, outlier_thres=self.outlier_thres)
 
 def mad(data, bkg=None):
+    """Compute the median asbolute deviation. optionally provide a 
+    precomuted background measure
+    """
     bkg = bkg if bkg else np.median(data)
     return np.median(np.abs(data - bkg))
 
@@ -83,7 +102,29 @@ def fit_bkg_rms_estimate(
     bin_perc: float = 0.25,
     outlier_thres: float = 3.0,
 ) -> BANEResult:
+    """An over the top attempt at robustly characterising the
+    back ground and RMS. Data will first be flagged via the MAD,
+    then bin, then those bin counts are used to fit for a gaussian. 
     
+    Only bins that are above 25 percent of the maximum bin count 
+    are used in the fitting process. 
+
+    Parameters
+    ----------
+    data : np.ndarray
+        Data to be estimated
+    clip_rounds : int, optional
+        Number of clipping rounds, by default 2
+    bin_perc : float, optional
+        Minimum set of counts, relative to the max count bin, that any bin should have. Less than this and they are discarded, by default 0.25
+    outlier_thres : float, optional
+        Clipping threshold to use, by default 3.0
+
+    Returns
+    -------
+    BANEResult
+        Backgroun and noise estimation
+    """
     data = data[np.isfinite(data)]
 
     cen_func = np.median
@@ -132,7 +173,7 @@ class SigmaClip(NamedTuple):
     def perform(self, data: np.ndarray) -> BANEResult:
         return sigmaclip(arr=data, lo=self.low, hi=self.high)
 
-def sigmaclip(arr, lo, hi, reps=10) -> BANEResult:
+def sigmaclip(arr, lo, hi, reps=10) -> BANEResult:      
     """
     Perform sigma clipping on an array, ignoring non finite values.
 

--- a/AegeanTools/sigma.py
+++ b/AegeanTools/sigma.py
@@ -1,0 +1,159 @@
+"""Tooling around the rms and background estimation"""
+
+from re import L
+from typing import Tuple, NamedTuple
+import logging 
+
+import numpy as np
+from scipy.stats import norm, normaltest
+from astropy.stats import mad_std, sigma_clip
+
+class FittedSigmaClip(NamedTuple):
+    """Arguments for the fitted_sigma_clip"""
+    sigma: int = 3 
+    """Threshhold before clipped"""
+
+def fitted_mean(data: np.ndarray) -> float:
+    mean, _ = norm.fit(data)
+    return mean
+
+
+def fitted_std(data: np.ndarray) -> float:
+    _, std = norm.fit(data)
+    return std
+
+def fitted_sigma_clip(data: np.ndarray, sigma: int=3) -> Tuple[float,float]:
+    
+    data = data[np.isfinite(data)]
+    
+    clipped_plane = sigma_clip(
+        data.flatten(), 
+        sigma=3, 
+        cenfunc=fitted_mean, 
+        stdfunc=fitted_std, 
+        maxiters=None
+    )
+    bkg, rms = norm.fit(clipped_plane.compressed())
+
+
+class FitBkgRmsEstimate(NamedTuple):
+    """Options for the fitting approach method"""
+    clip_rounds: int = 3
+    """Number of clipping rounds to perform"""
+    bin_perc: float = 0.25
+    """Minimum fraction of the histogram bins, or something"""
+    outlier_thres: float = 3.0
+    """Threshold that a data point should be at to be considered an outlier"""
+
+def mad(data, bkg=None):
+    bkg = bkg if bkg else np.median(data)
+    return np.median(np.abs(data - bkg))
+
+def fit_bkg_rms_estimate(
+    data: np.ndarray,
+    clip_rounds: int = 2,
+    bin_perc: float = 0.25,
+    outlier_thres: float = 3.0,
+) -> Tuple[float,float]:
+    
+    data = data[np.isfinite(data)]
+
+    cen_func = np.median
+
+    bkg = cen_func(data)
+
+    for i in range(clip_rounds):
+        data = data[np.abs(data - bkg) < outlier_thres * mad(data, bkg=bkg)]
+        bkg = cen_func(data)
+
+    # Attempts to ensure a sane number of bins to fit against
+    mask_counts = 0
+    loop = 1
+    while True:
+        counts, binedges = np.histogram(data, bins=50 * loop)
+
+        mask = counts >= bin_perc * np.max(counts)
+        mask_counts = np.sum(mask)
+        loop += 1
+
+        if not (mask_counts < 5 and loop < 5): 
+            break
+
+    binc = (binedges[:-1] + binedges[1:]) / 2
+    p = np.polyfit(binc[mask], np.log10(counts[mask] / np.max(counts)), 2)
+    a, b, c = p
+
+    x1 = (-b + np.sqrt(b ** 2 - 4.0 * a * (c - np.log10(0.5)))) / (2.0 * a)
+    x2 = (-b - np.sqrt(b ** 2 - 4.0 * a * (c - np.log10(0.5)))) / (2.0 * a)
+    fwhm = np.abs(x1 - x2)
+    noise = fwhm / 2.355
+
+    return float(bkg), noise
+
+
+
+class SigmaClip(NamedTuple):
+    """Container for the original sigma clipping method"""
+    low: float = 3.0
+    """Low sigma clip threshhold"""
+    high: float = 3.0
+    """High sigma clip threshhold"""
+
+def sigmaclip(arr, lo, hi, reps=10):
+    """
+    Perform sigma clipping on an array, ignoring non finite values.
+
+    During each iteration return an array whose elements c obey:
+    mean -std*lo < c < mean + std*hi
+
+    where mean/std are the mean std of the input array.
+
+    Parameters
+    ----------
+    arr : iterable
+        An iterable array of numeric types.
+    lo : float
+        The negative clipping level.
+    hi : float
+        The positive clipping level.
+    reps : int
+        The number of iterations to perform. Default = 3.
+
+    Returns
+    -------
+    mean : float
+        The mean of the array, possibly nan
+    std : float
+        The std of the array, possibly nan
+
+    Notes
+    -----
+    Scipy v0.16 now contains a comparable method that will ignore nan/inf
+    values.
+    """
+    clipped = np.array(arr)[np.isfinite(arr)]
+
+    if len(clipped) < 1:
+        return np.nan, np.nan
+
+    std = np.std(clipped)
+    mean = np.mean(clipped)
+    prev_valid = len(clipped)
+    for count in range(int(reps)):
+        mask = (clipped > mean-std*lo) & (clipped < mean+std*hi)
+        clipped = clipped[mask]
+
+        curr_valid = len(clipped)
+        if curr_valid < 1:
+            break
+        # No change in statistics if no change is noted
+        if prev_valid == curr_valid:
+            break
+        std = np.std(clipped)
+        mean = np.mean(clipped)
+        prev_valid = curr_valid
+    else:
+        logging.debug(
+            "No stopping criteria was reached after {0} cycles".format(count))
+
+    return mean, std

--- a/AegeanTools/sigma.py
+++ b/AegeanTools/sigma.py
@@ -1,25 +1,35 @@
 """Tooling around the rms and background estimation"""
 
 from re import L
-from typing import Tuple, NamedTuple
+from typing import Tuple, NamedTuple, Optional
 import logging 
 
 import numpy as np
-from scipy.stats import norm, normaltest
-from astropy.stats import mad_std, sigma_clip
+from scipy.stats import norm
+from astropy.stats import sigma_clip
 
 class FittedSigmaClip(NamedTuple):
     """Arguments for the fitted_sigma_clip"""
     sigma: int = 3 
     """Threshhold before clipped"""
 
-def fitted_mean(data: np.ndarray) -> float:
+def fitted_mean(data: np.ndarray, axis: Optional[int] =None) -> float:
+    if axis is not None:
+        # This is to make astropy sigma clip happy
+        raise NotImplementedError("Unexpected axis keyword. ")
+    
     mean, _ = norm.fit(data)
+    
     return mean
 
 
-def fitted_std(data: np.ndarray) -> float:
+def fitted_std(data: np.ndarray, axis: Optional[int]=None) -> float:
+    if axis is not None:
+        # This is to make astropy sigma clip happy
+        raise NotImplementedError("Unexpected axis keyword. ")
+    
     _, std = norm.fit(data)
+    
     return std
 
 def fitted_sigma_clip(data: np.ndarray, sigma: int=3) -> Tuple[float,float]:
@@ -29,12 +39,13 @@ def fitted_sigma_clip(data: np.ndarray, sigma: int=3) -> Tuple[float,float]:
     clipped_plane = sigma_clip(
         data.flatten(), 
         sigma=3, 
-        cenfunc=fitted_mean, 
+        cenfunc=np.median, 
         stdfunc=fitted_std, 
         maxiters=None
     )
     bkg, rms = norm.fit(clipped_plane.compressed())
 
+    return float(bkg), float(rms)
 
 class FitBkgRmsEstimate(NamedTuple):
     """Options for the fitting approach method"""


### PR DESCRIPTION
I got a little carried away when looking at changing the way bane calculates the background and rms. I have added some other modes that can be specified on the CLI. 

There is also the start of an adaptive box size mode. The idea being that different box car sizes (and potentially smoothed scales) could be used. At the moment the only consideration that is made is the number of pixels that survived the clipping. If too many pixels were clipped, use a larger box. 

I have also rejigged the code a little to separate out the logic a little more clearly, and try to separate out the functions into smaller more isolated units of work. 