### PR TITLE
Add support for output catalogues with crtf format

### DIFF
--- a/AegeanTools/catalogs.py
+++ b/AegeanTools/catalogs.py
@@ -568,61 +568,6 @@ def writeIslandContours(filename, catalog, fmt="reg"):
     return
 
 
-def writeIslandBoxes(filename, catalog, fmt):
-    """
-    Write an output file in ds9 .reg, or kvis .ann format that contains
-    bounding boxes for all the islands.
-
-    Parameters
-    ----------
-    filename : str
-        Filename to write.
-
-    catalog : list
-        List of sources. Only those of type
-        :class:`AegeanTools.models.IslandSource` will have contours drawn.
-
-    fmt : str
-        Output format type. Currently only 'reg' and 'ann' are supported.
-        Default = 'reg'.
-
-    Returns
-    -------
-    None
-
-    See Also
-    --------
-    :func:`AegeanTools.catalogs.writeIslandContours`
-    """
-    if fmt not in ["reg", "ann"]:
-        logger.warning("Format not supported for island boxes{0}".format(fmt))
-        return  # fmt not supported
-
-    out = open(filename, "w")
-    print("#Aegean Islands", file=out)
-    print("#Aegean version {0}-({1})".format(__version__, __date__), file=out)
-
-    if fmt == "reg":
-        print("IMAGE", file=out)
-        box_fmt = "box({0},{1},{2},{3}) #{4}"
-    else:
-        print("COORD P", file=out)
-        box_fmt = "box P {0} {1} {2} {3} #{4}"
-
-    for c in catalog:
-        # x/y swap for pyfits/numpy translation
-        ymin, ymax, xmin, xmax = c.extent
-        # +1 for array/image offset
-        xcen = (xmin + xmax) / 2.0 + 1
-        # + 0.5 in each direction to make lines run 'between' DS9 pixels
-        xwidth = xmax - xmin + 1
-        ycen = (ymin + ymax) / 2.0 + 1
-        ywidth = ymax - ymin + 1
-        print(box_fmt.format(xcen, ycen, xwidth, ywidth, c.island), file=out)
-    out.close()
-    return
-
-
 def writeAnn(filename, catalog, fmt):
     """
     Write an annotation file that can be read by Kvis (.ann) or DS9 (.reg).

--- a/AegeanTools/catalogs.py
+++ b/AegeanTools/catalogs.py
@@ -733,9 +733,9 @@ def writeCRTF(filename, catalog, fmt):
     if len(components) > 0:
         cat = sorted(components)
         suffix = "comp"
-    elif len(simples) > 0:
-        cat = simples
-        suffix = "simp"
+    # elif len(simples) > 0:
+    #     cat = simples
+    #     suffix = "simp"
     else:
         cat = []
 

--- a/AegeanTools/catalogs.py
+++ b/AegeanTools/catalogs.py
@@ -729,36 +729,27 @@ def writeAnn(filename, catalog, fmt):
 
 def writeCRTF(filename, catalog, fmt):
     """ """
-    components, islands, simples = classify_catalog(catalog)
+    components, islands, _ = classify_catalog(catalog)
+
     if len(components) > 0:
-        cat = sorted(components)
-        suffix = "comp"
-    # elif len(simples) > 0:
-    #     cat = simples
-    #     suffix = "simp"
-    else:
-        cat = []
-
-    if len(cat) > 0:
-        ras = [a.ra_str for a in cat]
-        decs = [re.sub(":", ".", a.dec_str) for a in cat]
+        ras = [a.ra_str for a in components]
+        decs = [re.sub(":", ".", a.dec_str) for a in components]
         # a being the variable that I used for bmaj.
-        if not hasattr(cat[0], "a"):
-            bmajs = [30 for a in cat]
+        if not hasattr(components[0], "a"):
+            bmajs = [30 for a in components]
             bmins = bmajs
-            pas = [0 for a in cat]
+            pas = [0 for a in components]
         else:
-            bmajs = [a.a for a in cat]
-            bmins = [a.b for a in cat]
-            pas = [a.pa for a in cat]
+            bmajs = [a.a for a in components]
+            bmins = [a.b for a in components]
+            pas = [a.pa for a in components]
 
-        names = [a.__repr__() for a in cat]
-        new_file = re.sub(".crtf$", "_{0}.crtf".format(suffix), filename)
+        names = [a.__repr__() for a in components]
+        new_file = re.sub(".crtf$", "_{0}.crtf".format("comp"), filename)
 
         with open(new_file, "w") as out:
             out.write("#CRTFv0 CASA Region Text Format version 0\n")
             out.write(f"#Aegean version {__version__}-({__date__})\n")
-            # out.write("global coord=J2000\n")
 
             for ra, dec, bmaj, bmin, pa, name in zip(
                 ras, decs, bmajs, bmins, pas, names
@@ -774,9 +765,7 @@ def writeCRTF(filename, catalog, fmt):
 
     if len(islands) > 0:
         logger.warning(f"format {fmt} not supported for island annotations")
-        return
-        # writeIslandContours(new_file, islands, fmt)
-        # logger.info("wrote {0}".format(new_file))
+
     return
 
 

--- a/AegeanTools/catalogs.py
+++ b/AegeanTools/catalogs.py
@@ -21,6 +21,7 @@ __author__ = "Paul Hancock"
 __version__ = "1.1"
 __date__ = "2022-07-15"
 
+
 # writing table formats
 def check_table_formats(files):
     """
@@ -38,7 +39,7 @@ def check_table_formats(files):
     """
     cont = True
     formats = get_table_formats()
-    for t in files.split(','):
+    for t in files.split(","):
         _, ext = os.path.splitext(t)
         ext = ext[1:].lower()
         if ext not in formats:
@@ -69,7 +70,9 @@ def show_formats():
         "vot": "VO-Table",
         "xml": "VO-Table",
         "db": "Sqlite3 database",
-        "sqlite": "Sqlite3 database"}
+        "sqlite": "Sqlite3 database",
+        "crtf": "CASA Region Text Format",
+    }
     supported = get_table_formats()
     print("Extension |     Description       | Supported?")
     for k in sorted(fmts.keys()):
@@ -86,15 +89,11 @@ def get_table_formats():
     fmts : list
         A list of file name extensions that are supported.
     """
-    fmts = ['reg', 'fits']
-    fmts.extend(['vo', 'vot', 'xml'])
-    fmts.extend(['csv', 'tab', 'tex', 'html'])
-    # if hdf5_supported:
-    #     fmts.append('hdf5')
-    # else:
-    #     logger.info("HDF5 is not supported by your environment")
-    # assume this is always possible -> though it may not be on some systems
-    fmts.extend(['db', 'sqlite'])
+    fmts = ["reg", "fits"]
+    fmts.extend(["vo", "vot", "xml"])
+    fmts.extend(["csv", "tab", "tex", "html"])
+    fmts.extend(["db", "sqlite"])
+    fmts.extend(["crtf"])
     return fmts
 
 
@@ -114,11 +113,11 @@ def update_meta_data(meta=None):
     """
     if meta is None:
         meta = {}
-    if 'DATE' not in meta:
-        meta['DATE'] = strftime("%Y-%m-%d %H:%M:%S", gmtime())
-    if 'PROGRAM' not in meta:
-        meta['PROGRAM'] = "AegeanTools.catalogs"
-        meta['PROGVER'] = "{0}-({1})".format(__version__, __date__)
+    if "DATE" not in meta:
+        meta["DATE"] = strftime("%Y-%m-%d %H:%M:%S", gmtime())
+    if "PROGRAM" not in meta:
+        meta["PROGRAM"] = "AegeanTools.catalogs"
+        meta["PROGVER"] = "{0}-({1})".format(__version__, __date__)
     return meta
 
 
@@ -155,25 +154,30 @@ def save_catalog(filename, catalog, meta=None, prefix=None):
     -------
     None
     """
-    ascii_table_formats = {'csv': 'csv',
-                           'tab': 'tab', 'tex': 'latex', 'html': 'html'}
+    ascii_table_formats = {"csv": "csv", "tab": "tab", "tex": "latex", "html": "html"}
     # .ann and .reg are handled by me
     meta = update_meta_data(meta)
     extension = os.path.splitext(filename)[1][1:].lower()
-    if extension in ['ann', 'reg']:
+    if extension in ["ann", "reg"]:
         writeAnn(filename, catalog, extension)
-    elif extension in ['db', 'sqlite']:
+    elif extension == "crtf":
+        writeCRTF(filename, catalog, extension)
+    elif extension in ["db", "sqlite"]:
         writeDB(filename, catalog, meta)
-    elif extension in ['hdf5', 'fits', 'vo', 'vot', 'xml']:
+    elif extension in ["hdf5", "fits", "vo", "vot", "xml"]:
         write_catalog(filename, catalog, extension, meta, prefix=prefix)
     elif extension in ascii_table_formats.keys():
-        write_catalog(filename, catalog,
-                      fmt=ascii_table_formats[extension],
-                      meta=meta, prefix=prefix)
+        write_catalog(
+            filename,
+            catalog,
+            fmt=ascii_table_formats[extension],
+            meta=meta,
+            prefix=prefix,
+        )
     else:
         logger.warning("extension not recognised {0}".format(extension))
         logger.warning("You get tab format")
-        write_catalog(filename, catalog, fmt='tab', prefix=prefix)
+        write_catalog(filename, catalog, fmt="tab", prefix=prefix)
     return
 
 
@@ -196,20 +200,23 @@ def load_catalog(filename):
 
     fmt = os.path.splitext(filename)[-1][1:].lower()  # extension sans '.'
 
-    if fmt in ['csv', 'tab', 'tex'] and fmt in supported:
+    if fmt in ["csv", "tab", "tex"] and fmt in supported:
         logger.info("Reading file {0}".format(filename))
         t = ascii.read(filename)
-        catalog = list(zip(t.columns['ra'], t.columns['dec']))
+        catalog = list(zip(t.columns["ra"], t.columns["dec"]))
 
-    elif fmt in ['vo', 'vot', 'xml'] and fmt in supported:
+    elif fmt in ["vo", "vot", "xml"] and fmt in supported:
         logger.info("Reading file {0}".format(filename))
         t = parse_single_table(filename)
-        catalog = list(zip(t.array['ra'].tolist(), t.array['dec'].tolist()))
+        catalog = list(zip(t.array["ra"].tolist(), t.array["dec"].tolist()))
 
     else:
         logger.info("Assuming ascii format, reading first two columns")
-        lines = [a.strip().split() for a in open(
-            filename, 'r').readlines() if not a.startswith('#')]
+        lines = [
+            a.strip().split()
+            for a in open(filename, "r").readlines()
+            if not a.startswith("#")
+        ]
         try:
             catalog = [(float(a[0]), float(a[1])) for a in lines]
         except ValueError as e:
@@ -241,10 +248,10 @@ def load_table(filename):
 
     fmt = os.path.splitext(filename)[-1][1:].lower()  # extension sans '.'
 
-    if fmt in ['csv', 'tab', 'tex'] and fmt in supported:
+    if fmt in ["csv", "tab", "tex"] and fmt in supported:
         logger.info("Reading file {0}".format(filename))
         t = ascii.read(filename)
-    elif fmt in ['vo', 'vot', 'xml', 'fits', 'hdf5'] and fmt in supported:
+    elif fmt in ["vo", "vot", "xml", "fits", "hdf5"] and fmt in supported:
         logger.info("Reading file {0}".format(filename))
         t = Table.read(filename)
     else:
@@ -367,9 +374,9 @@ def write_catalog(filename, catalog, fmt=None, meta=None, prefix=None):
         meta = {}
 
     if prefix is None:
-        pre = ''
+        pre = ""
     else:
-        pre = prefix + '_'
+        pre = prefix + "_"
 
     def writer(filename, catalog, fmt=None):
         """
@@ -381,14 +388,14 @@ def write_catalog(filename, catalog, fmt=None, meta=None, prefix=None):
         for name in catalog[0].names:
             col_name = name
             if catalog[0].galactic:
-                if name.startswith('ra'):
-                    col_name = 'lon'+name[2:]
-                elif name.endswith('ra'):
-                    col_name = name[:-2] + 'lon'
-                elif name.startswith('dec'):
-                    col_name = 'lat'+name[3:]
-                elif name.endswith('dec'):
-                    col_name = name[:-3] + 'lat'
+                if name.startswith("ra"):
+                    col_name = "lon" + name[2:]
+                elif name.endswith("ra"):
+                    col_name = name[:-2] + "lon"
+                elif name.startswith("dec"):
+                    col_name = "lat" + name[3:]
+                elif name.endswith("dec"):
+                    col_name = name[:-3] + "lat"
             col_name = pre + col_name
             tab_dict[col_name] = [getattr(c, name, None) for c in catalog]
             name_list.append(col_name)
@@ -402,9 +409,9 @@ def write_catalog(filename, catalog, fmt=None, meta=None, prefix=None):
                 # description of this votable
                 vot.description = repr(meta)
                 writetoVO(vot, filename)
-            elif fmt in ['hdf5']:
-                t.write(filename, path='data', overwrite=True)
-            elif fmt in ['fits']:
+            elif fmt in ["hdf5"]:
+                t.write(filename, path="data", overwrite=True)
+            elif fmt in ["fits"]:
                 writeFITSTable(filename, t)
             else:
                 ascii.write(t, filename, fmt, overwrite=True)
@@ -416,15 +423,15 @@ def write_catalog(filename, catalog, fmt=None, meta=None, prefix=None):
     components, islands, simples = classify_catalog(catalog)
 
     if len(components) > 0:
-        new_name = "{1}{0}{2}".format('_comp', *os.path.splitext(filename))
+        new_name = "{1}{0}{2}".format("_comp", *os.path.splitext(filename))
         writer(new_name, components, fmt)
         logger.info("wrote {0}".format(new_name))
     if len(islands) > 0:
-        new_name = "{1}{0}{2}".format('_isle', *os.path.splitext(filename))
+        new_name = "{1}{0}{2}".format("_isle", *os.path.splitext(filename))
         writer(new_name, islands, fmt)
         logger.info("wrote {0}".format(new_name))
     if len(simples) > 0:
-        new_name = "{1}{0}{2}".format('_simp', *os.path.splitext(filename))
+        new_name = "{1}{0}{2}".format("_simp", *os.path.splitext(filename))
         writer(new_name, simples, fmt)
         logger.info("wrote {0}".format(new_name))
     return
@@ -451,6 +458,7 @@ def writeFITSTable(filename, table):
     Due to a bug in numpy, `int32` and `float32` are converted to `int64` and
     `float64` before writing.
     """
+
     def FITSTableType(val):
         """
         Return the FITSTable type corresponding to each named parameter in obj
@@ -464,8 +472,7 @@ def writeFITSTable(filename, table):
         elif isinstance(val, str):
             types = "{0}A".format(len(val))
         else:
-            logger.warning(
-                "Column {0} is of unknown type {1}".format(val, type(val)))
+            logger.warning("Column {0} is of unknown type {1}".format(val, type(val)))
             logger.warning("Using 5A")
             types = "5A"
         return types
@@ -473,21 +480,21 @@ def writeFITSTable(filename, table):
     cols = []
     for name in table.colnames:
         # Cause error columns to always be floats even when they are set to -1
-        if name.startswith('err_'):
-            fmt = 'E'
-        elif name == 'uuid':
-            fmt = '{0}A'.format(max(len(val) for val in table[name]))
+        if name.startswith("err_"):
+            fmt = "E"
+        elif name == "uuid":
+            fmt = "{0}A".format(max(len(val) for val in table[name]))
         else:
             fmt = FITSTableType(table[name][0])
         cols.append(fits.Column(name=name, format=fmt, array=table[name]))
     cols = fits.ColDefs(cols)
     tbhdu = fits.BinTableHDU.from_columns(cols)
     for k in table.meta:
-        tbhdu.header['HISTORY'] = ':'.join((k, table.meta[k]))
+        tbhdu.header["HISTORY"] = ":".join((k, table.meta[k]))
     tbhdu.writeto(filename, overwrite=True)
 
 
-def writeIslandContours(filename, catalog, fmt='reg'):
+def writeIslandContours(filename, catalog, fmt="reg"):
     """
     Write an output file in ds9 .reg format that outlines the boundaries of
     each island.
@@ -512,39 +519,48 @@ def writeIslandContours(filename, catalog, fmt='reg'):
     --------
     :func:`AegeanTools.catalogs.writeIslandBoxes`
     """
-    if fmt != 'reg':
+    if fmt != "reg":
         logger.warning("Format {0} not yet supported".format(fmt))
         logger.warning("not writing anything")
         return
 
-    out = open(filename, 'w')
+    out = open(filename, "w")
     print("#Aegean island contours", file=out)
-    print("#AegeanTools.catalogs version {0}-({1})".format(
-        __version__, __date__),
-        file=out)
-    line_fmt = 'image;line({0},{1},{2},{3})'
-    text_fmt = 'fk5; text({0},{1}) # text={{{2}}}'
-    mas_fmt = 'image; line({1},{0},{3},{2}) #color = yellow'
-    x_fmt = 'image; point({1},{0}) # point=x'
+    print(
+        "#AegeanTools.catalogs version {0}-({1})".format(__version__, __date__),
+        file=out,
+    )
+    line_fmt = "image;line({0},{1},{2},{3})"
+    text_fmt = "fk5; text({0},{1}) # text={{{2}}}"
+    mas_fmt = "image; line({1},{0},{3},{2}) #color = yellow"
+    x_fmt = "image; point({1},{0}) # point=x"
     for c in catalog:
         contour = c.contour
         if len(contour) > 1:
             for p1, p2 in zip(contour[:-1], contour[1:]):
-                print(line_fmt.format(
-                      p1[1] + 0.5, p1[0] + 0.5, p2[1] + 0.5, p2[0] + 0.5),
-                      file=out)
-            print(line_fmt.format(contour[-1][1] + 0.5, contour[-1][0] + 0.5,
-                                  contour[0][1] + 0.5, contour[0][0] + 0.5),
-                  file=out)
+                print(
+                    line_fmt.format(p1[1] + 0.5, p1[0] + 0.5, p2[1] + 0.5, p2[0] + 0.5),
+                    file=out,
+                )
+            print(
+                line_fmt.format(
+                    contour[-1][1] + 0.5,
+                    contour[-1][0] + 0.5,
+                    contour[0][1] + 0.5,
+                    contour[0][0] + 0.5,
+                ),
+                file=out,
+            )
         # comment out lines that have invalid ra/dec (WCS problems)
         if np.nan in [c.ra, c.dec]:
-            print('#', end=' ', file=out)
+            print("#", end=" ", file=out)
         # some islands may not have anchors because they don't have any
         # contours
         if len(c.max_angular_size_anchors) == 4:
             print(text_fmt.format(c.ra, c.dec, c.island), file=out)
-            print(mas_fmt.format(
-                *[a + 0.5 for a in c.max_angular_size_anchors]), file=out)
+            print(
+                mas_fmt.format(*[a + 0.5 for a in c.max_angular_size_anchors]), file=out
+            )
         for p1, p2 in c.pix_mask:
             # DS9 uses 1-based instead of 0-based indexing
             print(x_fmt.format(p1 + 1, p2 + 1), file=out)
@@ -578,20 +594,20 @@ def writeIslandBoxes(filename, catalog, fmt):
     --------
     :func:`AegeanTools.catalogs.writeIslandContours`
     """
-    if fmt not in ['reg', 'ann']:
+    if fmt not in ["reg", "ann"]:
         logger.warning("Format not supported for island boxes{0}".format(fmt))
         return  # fmt not supported
 
-    out = open(filename, 'w')
+    out = open(filename, "w")
     print("#Aegean Islands", file=out)
     print("#Aegean version {0}-({1})".format(__version__, __date__), file=out)
 
-    if fmt == 'reg':
+    if fmt == "reg":
         print("IMAGE", file=out)
-        box_fmt = 'box({0},{1},{2},{3}) #{4}'
+        box_fmt = "box({0},{1},{2},{3}) #{4}"
     else:
         print("COORD P", file=out)
-        box_fmt = 'box P {0} {1} {2} {3} #{4}'
+        box_fmt = "box P {0} {1} {2} {3} #{4}"
 
     for c in catalog:
         # x/y swap for pyfits/numpy translation
@@ -638,7 +654,7 @@ def writeAnn(filename, catalog, fmt):
     --------
     AegeanTools.catalogs.writeIslandContours
     """
-    if fmt not in ['reg', 'ann']:
+    if fmt not in ["reg", "ann"]:
         logger.warning("Format not supported for island boxes{0}".format(fmt))
         return  # fmt not supported
 
@@ -656,7 +672,7 @@ def writeAnn(filename, catalog, fmt):
         ras = [a.ra for a in cat]
         decs = [a.dec for a in cat]
         # a being the variable that I used for bmaj.
-        if not hasattr(cat[0], 'a'):
+        if not hasattr(cat[0], "a"):
             bmajs = [30 / 3600.0 for a in cat]
             bmins = bmajs
             pas = [0 for a in cat]
@@ -666,48 +682,101 @@ def writeAnn(filename, catalog, fmt):
             pas = [a.pa for a in cat]
 
         names = [a.__repr__() for a in cat]
-        if fmt == 'ann':
-            new_file = re.sub('.ann$', '_{0}.ann'.format(suffix), filename)
-            out = open(new_file, 'w')
-            print("#Aegean version {0}-({1})".format(__version__, __date__),
-                  file=out)
-            print('PA SKY', file=out)
-            print('FONT hershey12', file=out)
-            print('COORD W', file=out)
-            formatter = "ELLIPSE W {0} {1} {2} {3} {4:+07.3f} #{5}" + \
-                        "\nTEXT W {0} {1} {5}"
+        if fmt == "ann":
+            new_file = re.sub(".ann$", "_{0}.ann".format(suffix), filename)
+            out = open(new_file, "w")
+            print("#Aegean version {0}-({1})".format(__version__, __date__), file=out)
+            print("PA SKY", file=out)
+            print("FONT hershey12", file=out)
+            print("COORD W", file=out)
+            formatter = (
+                "ELLIPSE W {0} {1} {2} {3} {4:+07.3f} #{5}" + "\nTEXT W {0} {1} {5}"
+            )
         else:  # reg
-            new_file = re.sub('.reg$', '_{0}.reg'.format(suffix), filename)
-            out = open(new_file, 'w')
-            print("#Aegean version {0}-({1})".format(__version__, __date__),
-                  file=out)
+            new_file = re.sub(".reg$", "_{0}.reg".format(suffix), filename)
+            out = open(new_file, "w")
+            print("#Aegean version {0}-({1})".format(__version__, __date__), file=out)
             print("fk5", file=out)
-            formatter = 'ellipse {0} {1} {2:.9f}d {3:.9f}d {4:+07.3f}d ' + \
-                        '# text="{5}"'
+            formatter = (
+                "ellipse {0} {1} {2:.9f}d {3:.9f}d {4:+07.3f}d " + '# text="{5}"'
+            )
             # DS9 has some strange ideas about position angle
             pas = [a - 90 for a in pas]
 
-        for ra, dec, bmaj, bmin, pa, name in zip(ras, decs,
-                                                 bmajs, bmins, pas, names):
+        for ra, dec, bmaj, bmin, pa, name in zip(ras, decs, bmajs, bmins, pas, names):
             # comment out lines that have invalid or stupid entries
             if np.nan in [ra, dec, bmaj, bmin, pa] or bmaj >= 180:
-                print('#', end=' ', file=out)
+                print("#", end=" ", file=out)
             print(formatter.format(ra, dec, bmaj, bmin, pa, name), file=out)
         out.close()
         logger.info("wrote {0}".format(new_file))
     if len(islands) > 0:
-        if fmt == 'reg':
-            new_file = re.sub('.reg$', '_isle.reg', filename)
-        elif fmt == 'ann':
-            logger.warning('kvis islands are currently not working')
+        if fmt == "reg":
+            new_file = re.sub(".reg$", "_isle.reg", filename)
+        elif fmt == "ann":
+            logger.warning("kvis islands are currently not working")
             return
         else:
             logger.warning(
-                'format {0} not supported for island annotations'.format(fmt))
+                "format {0} not supported for island annotations".format(fmt)
+            )
             return
         writeIslandContours(new_file, islands, fmt)
         logger.info("wrote {0}".format(new_file))
 
+    return
+
+
+def writeCRTF(filename, catalog, fmt):
+    """ """
+    components, islands, simples = classify_catalog(catalog)
+    if len(components) > 0:
+        cat = sorted(components)
+        suffix = "comp"
+    elif len(simples) > 0:
+        cat = simples
+        suffix = "simp"
+    else:
+        cat = []
+
+    if len(cat) > 0:
+        ras = [a.ra_str for a in cat]
+        decs = [re.sub(":", ".", a.dec_str) for a in cat]
+        # a being the variable that I used for bmaj.
+        if not hasattr(cat[0], "a"):
+            bmajs = [30 for a in cat]
+            bmins = bmajs
+            pas = [0 for a in cat]
+        else:
+            bmajs = [a.a for a in cat]
+            bmins = [a.b for a in cat]
+            pas = [a.pa for a in cat]
+
+        names = [a.__repr__() for a in cat]
+        new_file = re.sub(".crtf$", "_{0}.crtf".format(suffix), filename)
+
+        with open(new_file, "w") as out:
+            out.write("#CRTFv0 CASA Region Text Format version 0\n")
+            out.write(f"#Aegean version {__version__}-({__date__})\n")
+            # out.write("global coord=J2000\n")
+
+            for ra, dec, bmaj, bmin, pa, name in zip(
+                ras, decs, bmajs, bmins, pas, names
+            ):
+                # comment out lines that have invalid or stupid entries
+                if np.nan in [ra, dec, bmaj, bmin, pa] or bmaj >= 180 * 3600:
+                    out.write("# ")
+                out.write(
+                    f"ellipse[[{ra}, {dec}], [{bmaj:.2f}arcsec, {bmin:.2f}arcsec], {pa:.0f}deg], label='{name}', coord=J2000, color=green\n"
+                )
+
+        logger.info(f"wrote {new_file}")
+
+    if len(islands) > 0:
+        logger.warning(f"format {fmt} not supported for island annotations")
+        return
+        # writeIslandContours(new_file, islands, fmt)
+        # logger.info("wrote {0}".format(new_file))
     return
 
 
@@ -769,8 +838,7 @@ def writeDB(filename, catalog, meta=None):
             elif isinstance(val, str):
                 types.append("VARCHAR")
             else:
-                logger.warning(
-                    "Column {0} is of unknown type {1}".format(n, type(n)))
+                logger.warning("Column {0} is of unknown type {1}".format(n, type(n)))
                 logger.warning("Using VARCHAR")
                 types.append("VARCHAR")
         return types
@@ -781,17 +849,16 @@ def writeDB(filename, catalog, meta=None):
     conn = sqlite3.connect(filename)
     db = conn.cursor()
     # determine the column names by inspecting the catalog class
-    for t, tn in zip(classify_catalog(catalog),
-                     ["components", "islands", "simples"]):
+    for t, tn in zip(classify_catalog(catalog), ["components", "islands", "simples"]):
         if len(t) < 1:
             continue  # don't write empty tables
         col_names = t[0].names
         col_types = sqlTypes(t[0], col_names)
-        stmnt = ','.join(["{0} {1}".format(a, b)
-                         for a, b in zip(col_names, col_types)])
-        db.execute('CREATE TABLE {0} ({1})'.format(tn, stmnt))
-        stmnt = 'INSERT INTO {0} ({1}) VALUES ({2})'.format(
-            tn, ','.join(col_names), ','.join(['?' for i in col_names]))
+        stmnt = ",".join(["{0} {1}".format(a, b) for a, b in zip(col_names, col_types)])
+        db.execute("CREATE TABLE {0} ({1})".format(tn, stmnt))
+        stmnt = "INSERT INTO {0} ({1}) VALUES ({2})".format(
+            tn, ",".join(col_names), ",".join(["?" for i in col_names])
+        )
         # expend the iterators that are created by python 3+
         data = list(map(nulls, list(r.as_list() for r in t)))
         db.executemany(stmnt, data)
@@ -801,8 +868,9 @@ def writeDB(filename, catalog, meta=None):
     for k in meta:
         db.execute("INSERT INTO meta (key, val) VALUES (?,?)", (k, meta[k]))
     conn.commit()
-    logger.info(db.execute(
-        "SELECT name FROM sqlite_master WHERE type='table';").fetchall())
+    logger.info(
+        db.execute("SELECT name FROM sqlite_master WHERE type='table';").fetchall()
+    )
     conn.close()
     logger.info("Wrote file {0}".format(filename))
     return

--- a/tests/unit/test_catalogs.py
+++ b/tests/unit/test_catalogs.py
@@ -226,21 +226,6 @@ def test_write_contours_boxes():
     if os.path.exists("out.ann"):
         raise AssertionError()
 
-    cat.writeIslandBoxes("out.reg", catalog, fmt="reg")
-    if not os.path.exists("out.reg"):
-        raise AssertionError()
-
-    os.remove("out.reg")
-    cat.writeIslandBoxes("out.ann", catalog, fmt="ann")
-    if not os.path.exists("out.ann"):
-        raise AssertionError()
-
-    os.remove("out.ann")
-    # shouldn't write anything
-    cat.writeIslandBoxes("out.ot", catalog, fmt="ot")
-    if os.path.exists("out.ot"):
-        raise AssertionError()
-
 
 def test_write_ann():
     """Test that write_ann *doesn't* do anything"""

--- a/tests/unit/test_catalogs.py
+++ b/tests/unit/test_catalogs.py
@@ -25,7 +25,9 @@ def test_nulls():
 
 def test_check_table_formats():
     """Test check_table_formats"""
-    files = ",".join(["a.csv", "a.fits", "a.vot", "a.hdf5", "a.ann", "a.docx", "a"])
+    files = ",".join(
+        ["a.csv", "a.fits", "a.vot", "a.hdf5", "a.ann", "a.docx", "a.crtf", "a"]
+    )
 
     if cat.check_table_formats(files):
         raise AssertionError()
@@ -283,6 +285,22 @@ def test_write_ann():
     os.remove("out_isle.reg")
     cat.writeAnn("out.ann", [IslandSource()], fmt="ann")
     cat.writeAnn("out.reg", [IslandSource()], fmt="fail")
+
+
+def test_write_crtf():
+    """Test that we can save files in CASA region format."""
+    cat.writeCRTF("out.crtf", [ComponentSource()], fmt="crtf")
+    if not os.path.exists("out_comp.crtf"):
+        raise AssertionError("Failed to write component sources to crtf")
+    else:
+        os.remove("out_comp.crtf")
+
+    cat.writeCRTF("out.crtf", [IslandSource()], fmt="crtf")
+    if os.path.exists("out_isle.crft"):
+        os.remove("out_isle.crtf")
+        raise AssertionError("CRTF islands shouldn't be supported (yet)")
+
+    return
 
 
 def test_table_to_source_list():


### PR DESCRIPTION
This PR adds support for writing catalogues in .crtf format, meaning that people can now have annotations shown in CASA and CARTA.

Note that there seems to be no support for showing lines in pixel coordinates so this means that island contours are not provided.